### PR TITLE
lint checks

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -68,7 +68,8 @@ detekt {
         "mvvm/src/main/java",
         "dagger/src/main/java",
         "bindingadapters/src/main/java",
-        "interactors/src/main/java"
+        "interactors/src/main/java",
+        "mvvm-lint/src/main/java"
     )
     filters = ".*/resources/.*,.*/build/.*"
     config = files("detekt.yml")

--- a/buildSrc/src/main/kotlin/Deps.kt
+++ b/buildSrc/src/main/kotlin/Deps.kt
@@ -49,6 +49,13 @@ object Deps {
         const val rxIdler = "com.squareup.rx.idler:rx2-idler:${Versions.rxIdler}"
     }
 
+    object Lint {
+        const val core = "com.android.tools.lint:lint:${Versions.androidTools}"
+        const val api = "com.android.tools.lint:lint-api:${Versions.androidTools}"
+        const val checks = "com.android.tools.lint:lint-checks:${Versions.androidTools}"
+        const val tests = "com.android.tools.lint:lint-tests:${Versions.androidTools}"
+    }
+
     object Test {
         const val mockitoCore = "org.mockito:mockito-core:${Versions.mockitoCore}"
         const val androidXTestRunnner = "androidx.test:runner:${Versions.androidxTestRunner}"

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -31,6 +31,9 @@ object Versions {
     const val rxRelay = "2.1.0"
     const val rxDebug = "1.1.2"
 
+    // android tools
+    const val androidTools = "26.5.1"
+
     // test
     const val mockitoCore = "2.28.2"
     const val androidxTestRunner = "1.1.0"

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -31,6 +31,9 @@ object Versions {
     const val rxRelay = "2.1.0"
     const val rxDebug = "1.1.2"
 
+    // android tools
+    const val androidTools = "26.5.1"
+
     // test
     const val mockitoCore = "2.8.9"
     const val androidxTestRunner = "1.1.0"

--- a/mvvm-lint/build.gradle.kts
+++ b/mvvm-lint/build.gradle.kts
@@ -1,0 +1,17 @@
+plugins {
+    id("kotlin")
+}
+
+dependencies {
+    compileOnly(Deps.Lint.api)
+    compileOnly(Deps.Lint.checks)
+
+    testImplementation(Deps.Lint.core)
+    testImplementation(Deps.Lint.tests)
+}
+
+val jar by tasks.getting(Jar::class) {
+    manifest {
+        attributes["Lint-Registry-v2"] = "com.thefuntasty.lint.MvvmIssueRegistry"
+    }
+}

--- a/mvvm-lint/src/main/java/com/thefuntasty/lint/MvvmIssueRegistry.kt
+++ b/mvvm-lint/src/main/java/com/thefuntasty/lint/MvvmIssueRegistry.kt
@@ -5,5 +5,5 @@ import com.android.tools.lint.detector.api.Issue
 
 class MvvmIssueRegistry : IssueRegistry() {
 
-    override val issues: List<Issue> = listOf()
+    override val issues: List<Issue> = listOf(WrongEventNameDetector.ISSUE)
 }

--- a/mvvm-lint/src/main/java/com/thefuntasty/lint/MvvmIssueRegistry.kt
+++ b/mvvm-lint/src/main/java/com/thefuntasty/lint/MvvmIssueRegistry.kt
@@ -7,7 +7,7 @@ import com.android.tools.lint.detector.api.Issue
 class MvvmIssueRegistry : IssueRegistry() {
 
     override val issues: List<Issue> = listOf(
-        WrongEventNameDetector.ISSUE_SUFFIX,
+        WrongEventNameDetector.ISSUE_MUSSING_SUFFIX,
         WrongEventNameDetector.ISSUE_MISSPELL
     )
 

--- a/mvvm-lint/src/main/java/com/thefuntasty/lint/MvvmIssueRegistry.kt
+++ b/mvvm-lint/src/main/java/com/thefuntasty/lint/MvvmIssueRegistry.kt
@@ -1,0 +1,9 @@
+package com.thefuntasty.lint
+
+import com.android.tools.lint.client.api.IssueRegistry
+import com.android.tools.lint.detector.api.Issue
+
+class MvvmIssueRegistry : IssueRegistry() {
+
+    override val issues: List<Issue> = listOf()
+}

--- a/mvvm-lint/src/main/java/com/thefuntasty/lint/MvvmIssueRegistry.kt
+++ b/mvvm-lint/src/main/java/com/thefuntasty/lint/MvvmIssueRegistry.kt
@@ -1,9 +1,15 @@
 package com.thefuntasty.lint
 
 import com.android.tools.lint.client.api.IssueRegistry
+import com.android.tools.lint.detector.api.CURRENT_API
 import com.android.tools.lint.detector.api.Issue
 
 class MvvmIssueRegistry : IssueRegistry() {
 
-    override val issues: List<Issue> = listOf(WrongEventNameDetector.ISSUE)
+    override val issues: List<Issue> = listOf(
+        WrongEventNameDetector.ISSUE_SUFFIX,
+        WrongEventNameDetector.ISSUE_MISSPELL
+    )
+
+    override val api = CURRENT_API
 }

--- a/mvvm-lint/src/main/java/com/thefuntasty/lint/WrongEventNameDetector.kt
+++ b/mvvm-lint/src/main/java/com/thefuntasty/lint/WrongEventNameDetector.kt
@@ -15,7 +15,7 @@ import java.util.regex.Pattern
 class WrongEventNameDetector : Detector(), Detector.UastScanner {
 
     companion object {
-        val ISSUE_SUFFIX = Issue.create(
+        val ISSUE_MUSSING_SUFFIX = Issue.create(
             id = "MvvmEventNameMissingSuffix",
             briefDescription = "Wrong event name",
             explanation = "Event names should end with 'Event' suffix",
@@ -82,7 +82,7 @@ class WrongEventNameDetector : Detector(), Detector.UastScanner {
                     val suggestedName = "${declaration.name}Event"
 
                     context.report(
-                        issue = ISSUE_SUFFIX,
+                        issue = ISSUE_MUSSING_SUFFIX,
                         scopeClass = declaration,
                         location = context.getNameLocation(declaration),
                         message = "Event names should end with 'Event' suffix. Suggested name: $suggestedName",

--- a/mvvm-lint/src/main/java/com/thefuntasty/lint/WrongEventNameDetector.kt
+++ b/mvvm-lint/src/main/java/com/thefuntasty/lint/WrongEventNameDetector.kt
@@ -31,7 +31,7 @@ class WrongEventNameDetector : Detector(), Detector.UastScanner {
         val ISSUE_MISSPELL = Issue.create(
             id = "MvvmEventNameMisspell",
             briefDescription = "Misspelled event name",
-            explanation = "Event name is misspelled",
+            explanation = "Event name looks misspelled",
             category = Category.CORRECTNESS,
             priority = 5,
             severity = Severity.WARNING,

--- a/mvvm-lint/src/main/java/com/thefuntasty/lint/WrongEventNameDetector.kt
+++ b/mvvm-lint/src/main/java/com/thefuntasty/lint/WrongEventNameDetector.kt
@@ -10,12 +10,13 @@ import com.android.tools.lint.detector.api.Scope
 import com.android.tools.lint.detector.api.Severity
 import org.jetbrains.uast.UClass
 import java.util.EnumSet
+import java.util.regex.Pattern
 
 class WrongEventNameDetector : Detector(), Detector.UastScanner {
 
     companion object {
-        val ISSUE = Issue.create(
-            id = "MvvmWrongEventName",
+        val ISSUE_SUFFIX = Issue.create(
+            id = "MvvmEventNameMissingSuffix",
             briefDescription = "Wrong event name",
             explanation = "Event names should end with 'Event' suffix",
             category = Category.CORRECTNESS,
@@ -26,6 +27,22 @@ class WrongEventNameDetector : Detector(), Detector.UastScanner {
                 EnumSet.of(Scope.JAVA_FILE, Scope.TEST_SOURCES)
             )
         )
+
+        val ISSUE_MISSPELL = Issue.create(
+            id = "MvvmEventNameMisspell",
+            briefDescription = "Misspelled event name",
+            explanation = "Event name is misspelled",
+            category = Category.CORRECTNESS,
+            priority = 5,
+            severity = Severity.WARNING,
+            implementation = Implementation(
+                WrongEventNameDetector::class.java,
+                EnumSet.of(Scope.JAVA_FILE, Scope.TEST_SOURCES)
+            )
+        )
+
+        private val PATTERN_MISSPELL = Pattern.compile("Event[a-z]+")
+        private val PATTERN_SUFFIX = Pattern.compile("(.+Event)")
     }
 
     override fun getApplicableUastTypes() = listOf(UClass::class.java)
@@ -35,29 +52,50 @@ class WrongEventNameDetector : Detector(), Detector.UastScanner {
     override fun visitClass(context: JavaContext, declaration: UClass) {
         super.visitClass(context, declaration)
 
-        declaration.superClass?.let { superClass ->
-            if (context.evaluator.getQualifiedName(superClass) != "com.thefuntasty.mvvm.event.Event") {
-                if (declaration.name?.endsWith("Event") == false) {
+        val className = declaration.name
+
+        val isMvvmEvent = context.evaluator.getQualifiedName(declaration) == "com.thefuntasty.mvvm.event.Event"
+        val extendsMvvmEvent = declaration.superClass?.let { context.evaluator.getQualifiedName(it) } == "com.thefuntasty.mvvm.event.Event"
+
+        val isEligibleForDetection = isMvvmEvent.not() && extendsMvvmEvent.not()
+
+
+        if (className != null && isEligibleForDetection) {
+            when {
+                PATTERN_MISSPELL.matcher(className).find() -> {
+                    val suggestedName = PATTERN_SUFFIX.matcher(className).let {
+                        it.find()
+                        it.group(1)
+                    }
+
                     context.report(
-                        issue = ISSUE,
+                        issue = ISSUE_MISSPELL,
                         scopeClass = declaration,
                         location = context.getNameLocation(declaration),
-                        message = "Event names should end with 'Event' suffix. Suggested name: ${declaration.name}Event",
-                        quickfixData = createQuickFix(declaration)
+                        message = "Event name is misspelled. Suggested name: $suggestedName",
+                        quickfixData = createQuickFix(className, suggestedName)
+                    )
+                }
+
+                PATTERN_SUFFIX.matcher(className).find().not() -> {
+                    val suggestedName = "${declaration.name}Event"
+
+                    context.report(
+                        issue = ISSUE_SUFFIX,
+                        scopeClass = declaration,
+                        location = context.getNameLocation(declaration),
+                        message = "Event names should end with 'Event' suffix. Suggested name: $suggestedName",
+                        quickfixData = createQuickFix(className, suggestedName)
                     )
                 }
             }
         }
     }
 
-    private fun createQuickFix(declaration: UClass): LintFix? {
-        return declaration.name?.let { name ->
-            LintFix.create()
-                .name("Replace with ${name}Event")
-                .replace()
-                .text(name)
-                .with("${name}Event")
-                .build()
-        }
-    }
+    private fun createQuickFix(declarationName: String, replacement: String) = LintFix.create()
+        .name("Replace with $replacement")
+        .replace()
+        .text(declarationName)
+        .with(replacement)
+        .build()
 }

--- a/mvvm-lint/src/main/java/com/thefuntasty/lint/WrongEventNameDetector.kt
+++ b/mvvm-lint/src/main/java/com/thefuntasty/lint/WrongEventNameDetector.kt
@@ -55,10 +55,11 @@ class WrongEventNameDetector : Detector(), Detector.UastScanner {
         val className = declaration.name
 
         val isMvvmEvent = context.evaluator.getQualifiedName(declaration) == "com.thefuntasty.mvvm.event.Event"
-        val extendsMvvmEvent = declaration.superClass?.let { context.evaluator.getQualifiedName(it) } == "com.thefuntasty.mvvm.event.Event"
+        val extendsMvvmEvent = declaration.superClass?.let {
+            context.evaluator.getQualifiedName(it)
+        } == "com.thefuntasty.mvvm.event.Event"
 
         val isEligibleForDetection = isMvvmEvent.not() && extendsMvvmEvent.not()
-
 
         if (className != null && isEligibleForDetection) {
             when {

--- a/mvvm-lint/src/main/java/com/thefuntasty/lint/WrongEventNameDetector.kt
+++ b/mvvm-lint/src/main/java/com/thefuntasty/lint/WrongEventNameDetector.kt
@@ -5,6 +5,7 @@ import com.android.tools.lint.detector.api.Detector
 import com.android.tools.lint.detector.api.Implementation
 import com.android.tools.lint.detector.api.Issue
 import com.android.tools.lint.detector.api.JavaContext
+import com.android.tools.lint.detector.api.LintFix
 import com.android.tools.lint.detector.api.Scope
 import com.android.tools.lint.detector.api.Severity
 import org.jetbrains.uast.UClass
@@ -41,10 +42,22 @@ class WrongEventNameDetector : Detector(), Detector.UastScanner {
                         issue = ISSUE,
                         scopeClass = declaration,
                         location = context.getNameLocation(declaration),
-                        message = "Event names should end with 'Event' suffix. Suggested name: ${declaration.name}Event"
+                        message = "Event names should end with 'Event' suffix. Suggested name: ${declaration.name}Event",
+                        quickfixData = createQuickFix(declaration)
                     )
                 }
             }
+        }
+    }
+
+    private fun createQuickFix(declaration: UClass): LintFix? {
+        return declaration.name?.let { name ->
+            LintFix.create()
+                .name("Replace with ${name}Event")
+                .replace()
+                .text(name)
+                .with("${name}Event")
+                .build()
         }
     }
 }

--- a/mvvm-lint/src/main/java/com/thefuntasty/lint/WrongEventNameDetector.kt
+++ b/mvvm-lint/src/main/java/com/thefuntasty/lint/WrongEventNameDetector.kt
@@ -1,0 +1,50 @@
+package com.thefuntasty.lint
+
+import com.android.tools.lint.detector.api.Category
+import com.android.tools.lint.detector.api.Detector
+import com.android.tools.lint.detector.api.Implementation
+import com.android.tools.lint.detector.api.Issue
+import com.android.tools.lint.detector.api.JavaContext
+import com.android.tools.lint.detector.api.Scope
+import com.android.tools.lint.detector.api.Severity
+import org.jetbrains.uast.UClass
+import java.util.EnumSet
+
+class WrongEventNameDetector : Detector(), Detector.UastScanner {
+
+    companion object {
+        val ISSUE = Issue.create(
+            id = "MvvmWrongEventName",
+            briefDescription = "Wrong event name",
+            explanation = "Event names should end with 'Event' suffix",
+            category = Category.CORRECTNESS,
+            priority = 5,
+            severity = Severity.WARNING,
+            implementation = Implementation(
+                WrongEventNameDetector::class.java,
+                EnumSet.of(Scope.JAVA_FILE, Scope.TEST_SOURCES)
+            )
+        )
+    }
+
+    override fun getApplicableUastTypes() = listOf(UClass::class.java)
+
+    override fun applicableSuperClasses() = listOf("com.thefuntasty.mvvm.event.Event")
+
+    override fun visitClass(context: JavaContext, declaration: UClass) {
+        super.visitClass(context, declaration)
+
+        declaration.superClass?.let { superClass ->
+            if (context.evaluator.getQualifiedName(superClass) != "com.thefuntasty.mvvm.event.Event") {
+                if (declaration.name?.endsWith("Event") == false) {
+                    context.report(
+                        issue = ISSUE,
+                        scopeClass = declaration,
+                        location = context.getNameLocation(declaration),
+                        message = "Event names should end with 'Event' suffix. Suggested name: ${declaration.name}Event"
+                    )
+                }
+            }
+        }
+    }
+}

--- a/mvvm-lint/src/main/java/com/thefuntasty/lint/WrongEventNameDetector.kt
+++ b/mvvm-lint/src/main/java/com/thefuntasty/lint/WrongEventNameDetector.kt
@@ -41,23 +41,24 @@ class WrongEventNameDetector : Detector(), Detector.UastScanner {
             )
         )
 
+        private const val MVVM_EVENT_QUALIFIED_NAME = "com.thefuntasty.mvvm.event.Event"
         private val PATTERN_MISSPELL = Pattern.compile("Event[a-z]+")
         private val PATTERN_SUFFIX = Pattern.compile("(.+Event)")
     }
 
     override fun getApplicableUastTypes() = listOf(UClass::class.java)
 
-    override fun applicableSuperClasses() = listOf("com.thefuntasty.mvvm.event.Event")
+    override fun applicableSuperClasses() = listOf(MVVM_EVENT_QUALIFIED_NAME)
 
     override fun visitClass(context: JavaContext, declaration: UClass) {
         super.visitClass(context, declaration)
 
         val className = declaration.name
 
-        val isMvvmLibraryEvent = context.evaluator.getQualifiedName(declaration) == "com.thefuntasty.mvvm.event.Event"
+        val isMvvmLibraryEvent = context.evaluator.getQualifiedName(declaration) == MVVM_EVENT_QUALIFIED_NAME
         val directlyExtendsMvvmEvent = declaration.superClass?.let {
             context.evaluator.getQualifiedName(it)
-        } == "com.thefuntasty.mvvm.event.Event"
+        } == MVVM_EVENT_QUALIFIED_NAME
 
         val isEligibleForDetection = isMvvmLibraryEvent.not() && directlyExtendsMvvmEvent.not()
 

--- a/mvvm-lint/src/main/java/com/thefuntasty/lint/WrongEventNameDetector.kt
+++ b/mvvm-lint/src/main/java/com/thefuntasty/lint/WrongEventNameDetector.kt
@@ -33,7 +33,7 @@ class WrongEventNameDetector : Detector(), Detector.UastScanner {
             briefDescription = "Misspelled event name",
             explanation = "Event name looks misspelled",
             category = Category.CORRECTNESS,
-            priority = 5,
+            priority = 3,
             severity = Severity.WARNING,
             implementation = Implementation(
                 WrongEventNameDetector::class.java,

--- a/mvvm-lint/src/main/java/com/thefuntasty/lint/WrongEventNameDetector.kt
+++ b/mvvm-lint/src/main/java/com/thefuntasty/lint/WrongEventNameDetector.kt
@@ -54,12 +54,12 @@ class WrongEventNameDetector : Detector(), Detector.UastScanner {
 
         val className = declaration.name
 
-        val isMvvmEvent = context.evaluator.getQualifiedName(declaration) == "com.thefuntasty.mvvm.event.Event"
-        val extendsMvvmEvent = declaration.superClass?.let {
+        val isMvvmLibraryEvent = context.evaluator.getQualifiedName(declaration) == "com.thefuntasty.mvvm.event.Event"
+        val directlyExtendsMvvmEvent = declaration.superClass?.let {
             context.evaluator.getQualifiedName(it)
         } == "com.thefuntasty.mvvm.event.Event"
 
-        val isEligibleForDetection = isMvvmEvent.not() && extendsMvvmEvent.not()
+        val isEligibleForDetection = isMvvmLibraryEvent.not() && directlyExtendsMvvmEvent.not()
 
         if (className != null && isEligibleForDetection) {
             when {

--- a/mvvm-lint/src/test/java/com/thefuntasty/lint/WrongEventNameDetectorTest.kt
+++ b/mvvm-lint/src/test/java/com/thefuntasty/lint/WrongEventNameDetectorTest.kt
@@ -22,7 +22,7 @@ class WrongEventNameDetectorTest : LintDetectorTest() {
         """).indented()
 
     @Test
-    fun testBasic() {
+    fun testWarning() {
         lint().files(
             eventStub,
             kotlin("""
@@ -37,6 +37,25 @@ class WrongEventNameDetectorTest : LintDetectorTest() {
         )
             .issues(WrongEventNameDetector.ISSUE)
             .run()
-            .expectErrorCount(1)
+            .expectWarningCount(1)
+    }
+
+    @Test
+    fun testNoWarnings() {
+        lint().files(
+            eventStub,
+            kotlin("""
+                import com.thefuntasty.mvvm.event.Event
+                
+                sealed class MainEvent : Event<MainViewState>()
+                
+                object ShowDetailEvent : MainEvent()
+    
+                object ShowFormEvent : MainEvent()
+            """).indented()
+        )
+            .issues(WrongEventNameDetector.ISSUE)
+            .run()
+            .expectClean()
     }
 }

--- a/mvvm-lint/src/test/java/com/thefuntasty/lint/WrongEventNameDetectorTest.kt
+++ b/mvvm-lint/src/test/java/com/thefuntasty/lint/WrongEventNameDetectorTest.kt
@@ -12,7 +12,7 @@ class WrongEventNameDetectorTest : LintDetectorTest() {
     }
 
     override fun getIssues(): MutableList<Issue> {
-        return mutableListOf(WrongEventNameDetector.ISSUE_SUFFIX, WrongEventNameDetector.ISSUE_MISSPELL)
+        return mutableListOf(WrongEventNameDetector.ISSUE_MUSSING_SUFFIX, WrongEventNameDetector.ISSUE_MISSPELL)
     }
 
     private val eventStub = kotlin("""
@@ -40,7 +40,7 @@ class WrongEventNameDetectorTest : LintDetectorTest() {
                 object ShowForm : MainEvent()
             """).indented()
             )
-            .issues(WrongEventNameDetector.ISSUE_SUFFIX)
+            .issues(WrongEventNameDetector.ISSUE_MUSSING_SUFFIX)
             .run()
             .expectWarningCount(2)
     }
@@ -89,7 +89,7 @@ class WrongEventNameDetectorTest : LintDetectorTest() {
             """).indented()
             )
             .issues(
-                WrongEventNameDetector.ISSUE_SUFFIX,
+                WrongEventNameDetector.ISSUE_MUSSING_SUFFIX,
                 WrongEventNameDetector.ISSUE_MISSPELL
             )
             .run()

--- a/mvvm-lint/src/test/java/com/thefuntasty/lint/WrongEventNameDetectorTest.kt
+++ b/mvvm-lint/src/test/java/com/thefuntasty/lint/WrongEventNameDetectorTest.kt
@@ -1,0 +1,42 @@
+package com.thefuntasty.lint
+
+import com.android.tools.lint.checks.infrastructure.LintDetectorTest
+import com.android.tools.lint.detector.api.Detector
+import com.android.tools.lint.detector.api.Issue
+import org.junit.Test
+
+class WrongEventNameDetectorTest : LintDetectorTest() {
+
+    override fun getDetector(): Detector {
+        return WrongEventNameDetector()
+    }
+
+    override fun getIssues(): MutableList<Issue> {
+        return mutableListOf(WrongEventNameDetector.ISSUE)
+    }
+
+    private val eventStub = kotlin("""
+        package com.thefuntasty.mvvm.event
+        
+        abstract class Event<T>
+        """).indented()
+
+    @Test
+    fun testBasic() {
+        lint().files(
+            eventStub,
+            kotlin("""
+                import com.thefuntasty.mvvm.event.Event
+                
+                sealed class MainEvent : Event<MainViewState>()
+                
+                object ShowDetail : MainEvent()
+    
+                object ShowFormEvent : MainEvent()
+            """).indented()
+        )
+            .issues(WrongEventNameDetector.ISSUE)
+            .run()
+            .expectErrorCount(1)
+    }
+}

--- a/mvvm-lint/src/test/java/com/thefuntasty/lint/WrongEventNameDetectorTest.kt
+++ b/mvvm-lint/src/test/java/com/thefuntasty/lint/WrongEventNameDetectorTest.kt
@@ -22,7 +22,7 @@ class WrongEventNameDetectorTest : LintDetectorTest() {
         """).indented()
 
     @Test
-    fun testSuffixWarning() {
+    fun testMissingSuffixWarning() {
         lint()
             .files(
                 eventStub,

--- a/mvvm/build.gradle.kts
+++ b/mvvm/build.gradle.kts
@@ -38,6 +38,8 @@ dependencies {
     testImplementation(Deps.Test.assertJ)
     testImplementation(Deps.Test.mockitoKotlin)
     testImplementation(Deps.AndroidX.archTesting)
+
+    lintChecks(project(":mvvm-lint"))
 }
 
 project.apply {

--- a/mvvm/build.gradle.kts
+++ b/mvvm/build.gradle.kts
@@ -39,7 +39,7 @@ dependencies {
     testImplementation(Deps.Test.mockitoKotlin)
     testImplementation(Deps.AndroidX.archTesting)
 
-    lintChecks(project(":mvvm-lint"))
+    lintPublish(project(":mvvm-lint"))
 }
 
 project.apply {

--- a/mvvm/build.gradle.kts
+++ b/mvvm/build.gradle.kts
@@ -46,6 +46,8 @@ dependencies {
     testImplementation(Deps.AndroidX.archTesting)
     testImplementation(Deps.Test.robolectric)
     testImplementation(Deps.Test.androidXTestCore)
+
+    lintChecks(project(":mvvm-lint"))
 }
 
 project.apply {

--- a/mvvm/build.gradle.kts
+++ b/mvvm/build.gradle.kts
@@ -47,7 +47,7 @@ dependencies {
     testImplementation(Deps.Test.robolectric)
     testImplementation(Deps.Test.androidXTestCore)
 
-    lintChecks(project(":mvvm-lint"))
+    lintPublish(project(":mvvm-lint"))
 }
 
 project.apply {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -9,7 +9,8 @@ include(
     ":interactors",
     ":bindingadapters",
     ":cr-interactors",
-    ":templates"
+    ":templates",
+    ":mvvm-lint"
 )
 
 pluginManagement {


### PR DESCRIPTION
### Custom lint checks
Added 2 lint checks that will be published with `mvvm` module. Analysis is being performed on all classes that extend Event sealed class.

Implemented warnings:
- missing `Event` suffix in event name, example trigger: `object ShowLogin : MainEvent()`
- misspell of event name, example trigger: `object ShowLoginEventl : MainEvent()`

Related issue: #68 