### PR TITLE
Rename everyExecute to mockExecute

### DIFF
--- a/example/src/test/java/com/thefuntasty/mvvmsample/ui/login/fragment/LoginViewModelTest.kt
+++ b/example/src/test/java/com/thefuntasty/mvvmsample/ui/login/fragment/LoginViewModelTest.kt
@@ -1,7 +1,7 @@
 package com.thefuntasty.mvvmsample.ui.login.fragment
 
 import android.view.View
-import com.thefuntasty.mvvm.rxusecases.test.everyExecute
+import com.thefuntasty.mvvm.rxusecases.test.mockExecute
 import com.thefuntasty.mvvm.test.ViewModelTest
 import com.thefuntasty.mvvmsample.domain.GetStateUseCase
 import com.thefuntasty.mvvmsample.domain.ObserveUserFullNameUseCase
@@ -37,8 +37,8 @@ class LoginViewModelTest : ViewModelTest() {
     @Test
     fun `when onStart is called and get state is successful then header is visible`() {
         // GIVEN
-        mockObserveUserFullNameUseCase.everyExecute { Observable.never() }
-        mockGetStateUseCase.everyExecute(true) { Maybe.just(false) }
+        mockObserveUserFullNameUseCase.mockExecute { Observable.never() }
+        mockGetStateUseCase.mockExecute(true) { Maybe.just(false) }
 
         // WHEN
         viewModel.onStart()
@@ -50,8 +50,8 @@ class LoginViewModelTest : ViewModelTest() {
     @Test
     fun `when onStart is called and get state is not successful then header is not visible`() {
         // GIVEN
-        mockObserveUserFullNameUseCase.everyExecute { Observable.never() }
-        mockGetStateUseCase.everyExecute(true) { Maybe.empty() }
+        mockObserveUserFullNameUseCase.mockExecute { Observable.never() }
+        mockGetStateUseCase.mockExecute(true) { Maybe.empty() }
 
         // WHEN
         viewModel.onStart()
@@ -63,8 +63,8 @@ class LoginViewModelTest : ViewModelTest() {
     @Test
     fun `when onStart is called then full name is set to last observed value`() {
         // GIVEN
-        mockGetStateUseCase.everyExecute(true) { Maybe.never() }
-        mockObserveUserFullNameUseCase.everyExecute { Observable.just("first", "second") }
+        mockGetStateUseCase.mockExecute(true) { Maybe.never() }
+        mockObserveUserFullNameUseCase.mockExecute { Observable.just("first", "second") }
 
         // WHEN
         viewModel.onStart()
@@ -76,10 +76,10 @@ class LoginViewModelTest : ViewModelTest() {
     @Test
     fun `when login is called then name and surname is send to interactor`() {
         // GIVEN
-        mockGetStateUseCase.everyExecute(true) { Maybe.never() }
+        mockGetStateUseCase.mockExecute(true) { Maybe.never() }
         viewState.name.value = "name"
         viewState.surname.value = "surname"
-        mockLoginCompletabler.everyExecute { Completable.never() }
+        mockLoginCompletabler.mockExecute { Completable.never() }
 
         // WHEN
         viewModel.logIn()
@@ -91,7 +91,7 @@ class LoginViewModelTest : ViewModelTest() {
     @Test
     fun `when login is called and use case is successful then event is send`() {
         // GIVEN
-        mockLoginCompletabler.everyExecute { Completable.complete() }
+        mockLoginCompletabler.mockExecute { Completable.complete() }
 
         // WHEN
         viewModel.logIn()
@@ -103,7 +103,7 @@ class LoginViewModelTest : ViewModelTest() {
     @Test
     fun `when login is called and use case is not successful then event is send`() {
         // GIVEN
-        mockLoginCompletabler.everyExecute { Completable.error(IllegalStateException()) }
+        mockLoginCompletabler.mockExecute { Completable.error(IllegalStateException()) }
 
         // WHEN
         viewModel.logIn()

--- a/rx-usecases-test/src/main/java/com/thefuntasty/mvvm/rxusecases/test/CompletableUseCaseMock.kt
+++ b/rx-usecases-test/src/main/java/com/thefuntasty/mvvm/rxusecases/test/CompletableUseCaseMock.kt
@@ -16,11 +16,11 @@ import io.reactivex.disposables.Disposable
  * So when `Completable.complete` will be passed then `onComplete` will be called etc.
  *
  * Usage:
- * mockCompletableUseCase.everyExecute(args = ...) { Completable.complete() }
+ * mockCompletableUseCase.mockExecute(args = ...) { Completable.complete() }
  */
-inline fun <reified ARGS : Any, USE_CASE : CompletableUseCase<ARGS>> USE_CASE.everyExecute(args: ARGS, resultBlock: () -> Completable) {
+inline fun <reified ARGS : Any, USE_CASE : CompletableUseCase<ARGS>> USE_CASE.mockExecute(args: ARGS, resultBlock: () -> Completable) {
     mockCurrentDisposable()
-    every { this@everyExecute.create(args) } returns resultBlock()
+    every { this@mockExecute.create(args) } returns resultBlock()
 }
 
 /**
@@ -31,11 +31,11 @@ inline fun <reified ARGS : Any, USE_CASE : CompletableUseCase<ARGS>> USE_CASE.ev
  * So when `Completable.complete` will be passed then `onComplete` will be called etc.
  *
  * Usage:
- * mockCompletableUseCase.everyExecute(args = ...) { Completable.complete() }
+ * mockCompletableUseCase.mockExecute(args = ...) { Completable.complete() }
  */
-inline fun <reified ARGS : Any, USE_CASE : CompletableUseCase<ARGS>> USE_CASE.everyExecute(resultBlock: () -> Completable) {
+inline fun <reified ARGS : Any, USE_CASE : CompletableUseCase<ARGS>> USE_CASE.mockExecute(resultBlock: () -> Completable) {
     mockCurrentDisposable()
-    every { this@everyExecute.create(any()) } returns resultBlock()
+    every { this@mockExecute.create(any()) } returns resultBlock()
 }
 
 /**
@@ -46,11 +46,11 @@ inline fun <reified ARGS : Any, USE_CASE : CompletableUseCase<ARGS>> USE_CASE.ev
  * So when `Completable.complete` will be passed then `onComplete` will be called etc.
  *
  * Usage:
- * mockCompletableUseCase.everyExecute(args = ...) { Completable.complete() }
+ * mockCompletableUseCase.mockExecuteNullable(args = ...) { Completable.complete() }
  */
-inline fun <reified ARGS : Any?, USE_CASE : CompletableUseCase<ARGS?>> USE_CASE.everyExecuteNullable(args: ARGS, resultBlock: () -> Completable) {
+inline fun <reified ARGS : Any?, USE_CASE : CompletableUseCase<ARGS?>> USE_CASE.mockExecuteNullable(args: ARGS, resultBlock: () -> Completable) {
     mockCurrentDisposable()
-    every { this@everyExecuteNullable.create(args) } returns resultBlock()
+    every { this@mockExecuteNullable.create(args) } returns resultBlock()
 }
 
 /**
@@ -62,11 +62,11 @@ inline fun <reified ARGS : Any?, USE_CASE : CompletableUseCase<ARGS?>> USE_CASE.
  * So when `Completable.complete` will be passed then `onComplete` will be called etc.
  *
  * Usage:
- * mockCompletableUseCase.everyExecute(args = ...) { Completable.complete() }
+ * mockCompletableUseCase.mockExecuteNullable(args = ...) { Completable.complete() }
  */
-inline fun <reified ARGS : Any, USE_CASE : CompletableUseCase<ARGS?>> USE_CASE.everyExecuteNullable(resultBlock: () -> Completable) {
+inline fun <reified ARGS : Any, USE_CASE : CompletableUseCase<ARGS?>> USE_CASE.mockExecuteNullable(resultBlock: () -> Completable) {
     mockCurrentDisposable()
-    every { this@everyExecuteNullable.create(any()) } returns resultBlock()
+    every { this@mockExecuteNullable.create(any()) } returns resultBlock()
 }
 
 @PublishedApi

--- a/rx-usecases-test/src/main/java/com/thefuntasty/mvvm/rxusecases/test/FlowableUseCaseMock.kt
+++ b/rx-usecases-test/src/main/java/com/thefuntasty/mvvm/rxusecases/test/FlowableUseCaseMock.kt
@@ -16,11 +16,11 @@ import io.reactivex.disposables.Disposable
  * So when `Flowable.just` will be passed then `onNext` will be called etc.
  *
  * Usage:
- * mockFlowableUseCase.everyExecute(args = ...) { Flowable.just(...) }
+ * mockFlowableUseCase.mockExecute(args = ...) { Flowable.just(...) }
  */
-inline fun <reified ARGS : Any, RETURN_VALUE, USE_CASE : FlowableUseCase<ARGS, RETURN_VALUE>> USE_CASE.everyExecute(args: ARGS, resultBlock: () -> Flowable<RETURN_VALUE>) {
+inline fun <reified ARGS : Any, RETURN_VALUE, USE_CASE : FlowableUseCase<ARGS, RETURN_VALUE>> USE_CASE.mockExecute(args: ARGS, resultBlock: () -> Flowable<RETURN_VALUE>) {
     mockCurrentDisposable()
-    every { this@everyExecute.create(args) } returns resultBlock()
+    every { this@mockExecute.create(args) } returns resultBlock()
 }
 
 /**
@@ -31,11 +31,11 @@ inline fun <reified ARGS : Any, RETURN_VALUE, USE_CASE : FlowableUseCase<ARGS, R
  * So when `Flowable.just` will be passed then `onNext` will be called etc.
  *
  * Usage:
- * mockFlowableUseCase.everyExecute(args = ...) { Flowable.just(...) }
+ * mockFlowableUseCase.mockExecute(args = ...) { Flowable.just(...) }
  */
-inline fun <reified ARGS : Any, RETURN_VALUE, USE_CASE : FlowableUseCase<ARGS, RETURN_VALUE>> USE_CASE.everyExecute(resultBlock: () -> Flowable<RETURN_VALUE>) {
+inline fun <reified ARGS : Any, RETURN_VALUE, USE_CASE : FlowableUseCase<ARGS, RETURN_VALUE>> USE_CASE.mockExecute(resultBlock: () -> Flowable<RETURN_VALUE>) {
     mockCurrentDisposable()
-    every { this@everyExecute.create(any()) } returns resultBlock()
+    every { this@mockExecute.create(any()) } returns resultBlock()
 }
 
 /**
@@ -46,11 +46,11 @@ inline fun <reified ARGS : Any, RETURN_VALUE, USE_CASE : FlowableUseCase<ARGS, R
  * So when `Flowable.just` will be passed then `onNext` will be called etc.
  *
  * Usage:
- * mockFlowableUseCase.everyExecute(args = ...) { Flowable.just(...) }
+ * mockFlowableUseCase.mockExecuteNullable(args = ...) { Flowable.just(...) }
  */
-inline fun <reified ARGS : Any?, RETURN_VALUE, USE_CASE : FlowableUseCase<ARGS?, RETURN_VALUE>> USE_CASE.everyExecuteNullable(args: ARGS, resultBlock: () -> Flowable<RETURN_VALUE>) {
+inline fun <reified ARGS : Any?, RETURN_VALUE, USE_CASE : FlowableUseCase<ARGS?, RETURN_VALUE>> USE_CASE.mockExecuteNullable(args: ARGS, resultBlock: () -> Flowable<RETURN_VALUE>) {
     mockCurrentDisposable()
-    every { this@everyExecuteNullable.create(args) } returns resultBlock()
+    every { this@mockExecuteNullable.create(args) } returns resultBlock()
 }
 
 /**
@@ -62,11 +62,11 @@ inline fun <reified ARGS : Any?, RETURN_VALUE, USE_CASE : FlowableUseCase<ARGS?,
  * So when `Flowable.just` will be passed then `onNext` will be called etc.
  *
  * Usage:
- * mockFlowableUseCase.everyExecute(args = ...) { Flowable.just(...) }
+ * mockFlowableUseCase.mockExecuteNullable(args = ...) { Flowable.just(...) }
  */
-inline fun <reified ARGS : Any, RETURN_VALUE, USE_CASE : FlowableUseCase<ARGS?, RETURN_VALUE>> USE_CASE.everyExecuteNullable(resultBlock: () -> Flowable<RETURN_VALUE>) {
+inline fun <reified ARGS : Any, RETURN_VALUE, USE_CASE : FlowableUseCase<ARGS?, RETURN_VALUE>> USE_CASE.mockExecuteNullable(resultBlock: () -> Flowable<RETURN_VALUE>) {
     mockCurrentDisposable()
-    every { this@everyExecuteNullable.create(any()) } returns resultBlock()
+    every { this@mockExecuteNullable.create(any()) } returns resultBlock()
 }
 
 @PublishedApi

--- a/rx-usecases-test/src/main/java/com/thefuntasty/mvvm/rxusecases/test/MaybeUseCaseMock.kt
+++ b/rx-usecases-test/src/main/java/com/thefuntasty/mvvm/rxusecases/test/MaybeUseCaseMock.kt
@@ -16,11 +16,11 @@ import io.reactivex.disposables.Disposable
  * So when `Maybe.just` will be passed then `onNext` will be called etc.
  *
  * Usage:
- * mockMaybeUseCase.everyExecute(args = ...) { Maybe.just(...) }
+ * mockMaybeUseCase.mockExecute(args = ...) { Maybe.just(...) }
  */
-inline fun <reified ARGS : Any, RETURN_VALUE, USE_CASE : MaybeUseCase<ARGS, RETURN_VALUE>> USE_CASE.everyExecute(args: ARGS, resultBlock: () -> Maybe<RETURN_VALUE>) {
+inline fun <reified ARGS : Any, RETURN_VALUE, USE_CASE : MaybeUseCase<ARGS, RETURN_VALUE>> USE_CASE.mockExecute(args: ARGS, resultBlock: () -> Maybe<RETURN_VALUE>) {
     mockCurrentDisposable()
-    every { this@everyExecute.create(args) } returns resultBlock()
+    every { this@mockExecute.create(args) } returns resultBlock()
 }
 
 /**
@@ -31,11 +31,11 @@ inline fun <reified ARGS : Any, RETURN_VALUE, USE_CASE : MaybeUseCase<ARGS, RETU
  * So when `Maybe.just` will be passed then `onNext` will be called etc.
  *
  * Usage:
- * mockMaybeUseCase.everyExecute(args = ...) { Maybe.just(...) }
+ * mockMaybeUseCase.mockExecute(args = ...) { Maybe.just(...) }
  */
-inline fun <reified ARGS : Any, RETURN_VALUE, USE_CASE : MaybeUseCase<ARGS, RETURN_VALUE>> USE_CASE.everyExecute(resultBlock: () -> Maybe<RETURN_VALUE>) {
+inline fun <reified ARGS : Any, RETURN_VALUE, USE_CASE : MaybeUseCase<ARGS, RETURN_VALUE>> USE_CASE.mockExecute(resultBlock: () -> Maybe<RETURN_VALUE>) {
     mockCurrentDisposable()
-    every { this@everyExecute.create(any()) } returns resultBlock()
+    every { this@mockExecute.create(any()) } returns resultBlock()
 }
 
 /**
@@ -46,11 +46,11 @@ inline fun <reified ARGS : Any, RETURN_VALUE, USE_CASE : MaybeUseCase<ARGS, RETU
  * So when `Maybe.just` will be passed then `onNext` will be called etc.
  *
  * Usage:
- * mockMaybeUseCase.everyExecute(args = ...) { Maybe.just(...) }
+ * mockMaybeUseCase.mockExecuteNullable(args = ...) { Maybe.just(...) }
  */
-inline fun <reified ARGS : Any?, RETURN_VALUE, USE_CASE : MaybeUseCase<ARGS?, RETURN_VALUE>> USE_CASE.everyExecuteNullable(args: ARGS, resultBlock: () -> Maybe<RETURN_VALUE>) {
+inline fun <reified ARGS : Any?, RETURN_VALUE, USE_CASE : MaybeUseCase<ARGS?, RETURN_VALUE>> USE_CASE.mockExecuteNullable(args: ARGS, resultBlock: () -> Maybe<RETURN_VALUE>) {
     mockCurrentDisposable()
-    every { this@everyExecuteNullable.create(args) } returns resultBlock()
+    every { this@mockExecuteNullable.create(args) } returns resultBlock()
 }
 
 /**
@@ -62,11 +62,11 @@ inline fun <reified ARGS : Any?, RETURN_VALUE, USE_CASE : MaybeUseCase<ARGS?, RE
  * So when `Maybe.just` will be passed then `onNext` will be called etc.
  *
  * Usage:
- * mockMaybeUseCase.everyExecute(args = ...) { Maybe.just(...) }
+ * mockMaybeUseCase.mockExecuteNullable(args = ...) { Maybe.just(...) }
  */
-inline fun <reified ARGS : Any, RETURN_VALUE, USE_CASE : MaybeUseCase<ARGS?, RETURN_VALUE>> USE_CASE.everyExecuteNullable(resultBlock: () -> Maybe<RETURN_VALUE>) {
+inline fun <reified ARGS : Any, RETURN_VALUE, USE_CASE : MaybeUseCase<ARGS?, RETURN_VALUE>> USE_CASE.mockExecuteNullable(resultBlock: () -> Maybe<RETURN_VALUE>) {
     mockCurrentDisposable()
-    every { this@everyExecuteNullable.create(any()) } returns resultBlock()
+    every { this@mockExecuteNullable.create(any()) } returns resultBlock()
 }
 
 @PublishedApi

--- a/rx-usecases-test/src/main/java/com/thefuntasty/mvvm/rxusecases/test/ObservableUseCaseMock.kt
+++ b/rx-usecases-test/src/main/java/com/thefuntasty/mvvm/rxusecases/test/ObservableUseCaseMock.kt
@@ -16,11 +16,11 @@ import io.reactivex.disposables.Disposable
  * So when `Observable.just` will be passed then `onNext` will be called etc.
  *
  * Usage:
- * mockObservableUseCase.everyExecute(args = ...) { Observable.just(...) }
+ * mockObservableUseCase.mockExecute(args = ...) { Observable.just(...) }
  */
-inline fun <reified ARGS : Any, RETURN_VALUE, USE_CASE : ObservableUseCase<ARGS, RETURN_VALUE>> USE_CASE.everyExecute(args: ARGS, resultBlock: () -> Observable<RETURN_VALUE>) {
+inline fun <reified ARGS : Any, RETURN_VALUE, USE_CASE : ObservableUseCase<ARGS, RETURN_VALUE>> USE_CASE.mockExecute(args: ARGS, resultBlock: () -> Observable<RETURN_VALUE>) {
     mockCurrentDisposable()
-    every { this@everyExecute.create(args) } returns resultBlock()
+    every { this@mockExecute.create(args) } returns resultBlock()
 }
 
 /**
@@ -31,11 +31,11 @@ inline fun <reified ARGS : Any, RETURN_VALUE, USE_CASE : ObservableUseCase<ARGS,
  * So when `Observable.just` will be passed then `onNext` will be called etc.
  *
  * Usage:
- * mockObservableUseCase.everyExecute(args = ...) { Observable.just(...) }
+ * mockObservableUseCase.mockExecute(args = ...) { Observable.just(...) }
  */
-inline fun <reified ARGS : Any, RETURN_VALUE, USE_CASE : ObservableUseCase<ARGS, RETURN_VALUE>> USE_CASE.everyExecute(resultBlock: () -> Observable<RETURN_VALUE>) {
+inline fun <reified ARGS : Any, RETURN_VALUE, USE_CASE : ObservableUseCase<ARGS, RETURN_VALUE>> USE_CASE.mockExecute(resultBlock: () -> Observable<RETURN_VALUE>) {
     mockCurrentDisposable()
-    every { this@everyExecute.create(any()) } returns resultBlock()
+    every { this@mockExecute.create(any()) } returns resultBlock()
 }
 
 /**
@@ -46,11 +46,11 @@ inline fun <reified ARGS : Any, RETURN_VALUE, USE_CASE : ObservableUseCase<ARGS,
  * So when `Observable.just` will be passed then `onNext` will be called etc.
  *
  * Usage:
- * mockObservableUseCase.everyExecute(args = ...) { Observable.just(...) }
+ * mockObservableUseCase.mockExecuteNullable(args = ...) { Observable.just(...) }
  */
-inline fun <reified ARGS : Any?, RETURN_VALUE, USE_CASE : ObservableUseCase<ARGS?, RETURN_VALUE>> USE_CASE.everyExecuteNullable(args: ARGS, resultBlock: () -> Observable<RETURN_VALUE>) {
+inline fun <reified ARGS : Any?, RETURN_VALUE, USE_CASE : ObservableUseCase<ARGS?, RETURN_VALUE>> USE_CASE.mockExecuteNullable(args: ARGS, resultBlock: () -> Observable<RETURN_VALUE>) {
     mockCurrentDisposable()
-    every { this@everyExecuteNullable.create(args) } returns resultBlock()
+    every { this@mockExecuteNullable.create(args) } returns resultBlock()
 }
 
 /**
@@ -62,11 +62,11 @@ inline fun <reified ARGS : Any?, RETURN_VALUE, USE_CASE : ObservableUseCase<ARGS
  * So when `Observable.just` will be passed then `onNext` will be called etc.
  *
  * Usage:
- * mockObservableUseCase.everyExecute(args = ...) { Observable.just(...) }
+ * mockObservableUseCase.mockExecuteNullable(args = ...) { Observable.just(...) }
  */
-inline fun <reified ARGS : Any, RETURN_VALUE, USE_CASE : ObservableUseCase<ARGS?, RETURN_VALUE>> USE_CASE.everyExecuteNullable(resultBlock: () -> Observable<RETURN_VALUE>) {
+inline fun <reified ARGS : Any, RETURN_VALUE, USE_CASE : ObservableUseCase<ARGS?, RETURN_VALUE>> USE_CASE.mockExecuteNullable(resultBlock: () -> Observable<RETURN_VALUE>) {
     mockCurrentDisposable()
-    every { this@everyExecuteNullable.create(any()) } returns resultBlock()
+    every { this@mockExecuteNullable.create(any()) } returns resultBlock()
 }
 
 @PublishedApi

--- a/rx-usecases-test/src/main/java/com/thefuntasty/mvvm/rxusecases/test/SingleUseCaseMock.kt
+++ b/rx-usecases-test/src/main/java/com/thefuntasty/mvvm/rxusecases/test/SingleUseCaseMock.kt
@@ -16,11 +16,11 @@ import io.reactivex.disposables.Disposable
  * So when `Single.just` will be passed then `onSuccess` will be called etc.
  *
  * Usage:
- * mockSingleUseCase.everyExecute(args = ...) { Single.just(...) }
+ * mockSingleUseCase.mockExecute(args = ...) { Single.just(...) }
  */
-inline fun <reified ARGS : Any, RETURN_VALUE, USE_CASE : SingleUseCase<ARGS, RETURN_VALUE>> USE_CASE.everyExecute(args: ARGS, resultBlock: () -> Single<RETURN_VALUE>) {
+inline fun <reified ARGS : Any, RETURN_VALUE, USE_CASE : SingleUseCase<ARGS, RETURN_VALUE>> USE_CASE.mockExecute(args: ARGS, resultBlock: () -> Single<RETURN_VALUE>) {
     mockCurrentDisposable()
-    every { this@everyExecute.create(args) } returns resultBlock()
+    every { this@mockExecute.create(args) } returns resultBlock()
 }
 
 /**
@@ -31,11 +31,11 @@ inline fun <reified ARGS : Any, RETURN_VALUE, USE_CASE : SingleUseCase<ARGS, RET
  * So when `Single.just` will be passed then `onSuccess` will be called etc.
  *
  * Usage:
- * mockSingleUseCase.everyExecute { Single.just(...) }
+ * mockSingleUseCase.mockExecute { Single.just(...) }
  */
-inline fun <reified ARGS : Any, RETURN_VALUE, USE_CASE : SingleUseCase<ARGS, RETURN_VALUE>> USE_CASE.everyExecute(resultBlock: () -> Single<RETURN_VALUE>) {
+inline fun <reified ARGS : Any, RETURN_VALUE, USE_CASE : SingleUseCase<ARGS, RETURN_VALUE>> USE_CASE.mockExecute(resultBlock: () -> Single<RETURN_VALUE>) {
     mockCurrentDisposable()
-    every { this@everyExecute.create(any()) } returns resultBlock()
+    every { this@mockExecute.create(any()) } returns resultBlock()
 }
 
 /**
@@ -46,11 +46,11 @@ inline fun <reified ARGS : Any, RETURN_VALUE, USE_CASE : SingleUseCase<ARGS, RET
  * So when `Single.just` will be passed then `onSuccess` will be called etc.
  *
  * Usage:
- * mockSingleUseCase.everyExecute { Single.just(...) }
+ * mockSingleUseCase.mockExecuteNullable { Single.just(...) }
  */
-inline fun <reified ARGS : Any?, RETURN_VALUE, USE_CASE : SingleUseCase<ARGS?, RETURN_VALUE>> USE_CASE.everyExecuteNullable(args: ARGS, resultBlock: () -> Single<RETURN_VALUE>) {
+inline fun <reified ARGS : Any?, RETURN_VALUE, USE_CASE : SingleUseCase<ARGS?, RETURN_VALUE>> USE_CASE.mockExecuteNullable(args: ARGS, resultBlock: () -> Single<RETURN_VALUE>) {
     mockCurrentDisposable()
-    every { this@everyExecuteNullable.create(args) } returns resultBlock()
+    every { this@mockExecuteNullable.create(args) } returns resultBlock()
 }
 
 /**
@@ -62,11 +62,11 @@ inline fun <reified ARGS : Any?, RETURN_VALUE, USE_CASE : SingleUseCase<ARGS?, R
  * So when `Single.just` will be passed then `onSuccess` will be called etc.
  *
  * Usage:
- * mockSingleUseCase.everyExecute { Single.just(...) }
+ * mockSingleUseCase.mockExecuteNullable { Single.just(...) }
  */
-inline fun <reified ARGS : Any, RETURN_VALUE, USE_CASE : SingleUseCase<ARGS?, RETURN_VALUE>> USE_CASE.everyExecuteNullable(resultBlock: () -> Single<RETURN_VALUE>) {
+inline fun <reified ARGS : Any, RETURN_VALUE, USE_CASE : SingleUseCase<ARGS?, RETURN_VALUE>> USE_CASE.mockExecuteNullable(resultBlock: () -> Single<RETURN_VALUE>) {
     mockCurrentDisposable()
-    every { this@everyExecuteNullable.create(any()) } returns resultBlock()
+    every { this@mockExecuteNullable.create(any()) } returns resultBlock()
 }
 
 @PublishedApi

--- a/rx-usecases-test/src/test/java/com/thefuntasty/mvvm/rxusecases/test/CompletableUseCaseMethodsTests.kt
+++ b/rx-usecases-test/src/test/java/com/thefuntasty/mvvm/rxusecases/test/CompletableUseCaseMethodsTests.kt
@@ -33,7 +33,7 @@ class CompletableUseCaseMethodsTests : BaseTest() {
     @Test
     fun `when use case is mocked with just value then expected value should be returned`() {
         // GIVEN
-        mockUseCase.everyExecute(args) { Completable.complete() }
+        mockUseCase.mockExecute(args) { Completable.complete() }
 
         // WHEN
         val result = executeAndReturnResult()
@@ -45,7 +45,7 @@ class CompletableUseCaseMethodsTests : BaseTest() {
     @Test
     fun `when use case is mocked with just value and without args then expected value should be returned`() {
         // GIVEN
-        mockUseCase.everyExecute { Completable.complete() }
+        mockUseCase.mockExecute { Completable.complete() }
 
         // WHEN
         val result = executeAndReturnResult()
@@ -57,7 +57,7 @@ class CompletableUseCaseMethodsTests : BaseTest() {
     @Test
     fun `when nullable use case is mocked with just value then expected value should be returned`() {
         // GIVEN
-        mockUseCaseNullable.everyExecuteNullable(argsNullable) { Completable.complete() }
+        mockUseCaseNullable.mockExecuteNullable(argsNullable) { Completable.complete() }
 
         // WHEN
         val result = executeNullableAndReturnResult()
@@ -69,7 +69,7 @@ class CompletableUseCaseMethodsTests : BaseTest() {
     @Test
     fun `when nullable use case is mocked with just value and without args then expected value should be returned`() {
         // GIVEN
-        mockUseCaseNullable.everyExecuteNullable { Completable.complete() }
+        mockUseCaseNullable.mockExecuteNullable { Completable.complete() }
 
         // WHEN
         val result = executeNullableAndReturnResult()
@@ -81,7 +81,7 @@ class CompletableUseCaseMethodsTests : BaseTest() {
     @Test
     fun `when nullable use case is mocked with null value then expected value should be returned`() {
         // GIVEN
-        mockUseCaseNullable.everyExecuteNullable(null) { Completable.complete() }
+        mockUseCaseNullable.mockExecuteNullable(null) { Completable.complete() }
 
         // WHEN
         val result = executeNullAndReturnResult()

--- a/rx-usecases-test/src/test/java/com/thefuntasty/mvvm/rxusecases/test/FlowableUseCaseMethodsTests.kt
+++ b/rx-usecases-test/src/test/java/com/thefuntasty/mvvm/rxusecases/test/FlowableUseCaseMethodsTests.kt
@@ -33,7 +33,7 @@ class FlowableUseCaseMethodsTests : BaseTest() {
     @Test
     fun `when use case is mocked with just value then expected value should be returned`() {
         // GIVEN
-        mockUseCase.everyExecute(args) { Flowable.just(expectedResult) }
+        mockUseCase.mockExecute(args) { Flowable.just(expectedResult) }
 
         // WHEN
         val result = executeAndReturnResult()
@@ -45,7 +45,7 @@ class FlowableUseCaseMethodsTests : BaseTest() {
     @Test
     fun `when use case is mocked with just value and without args then expected value should be returned`() {
         // GIVEN
-        mockUseCase.everyExecute { Flowable.just(expectedResult) }
+        mockUseCase.mockExecute { Flowable.just(expectedResult) }
 
         // WHEN
         val result = executeAndReturnResult()
@@ -57,7 +57,7 @@ class FlowableUseCaseMethodsTests : BaseTest() {
     @Test
     fun `when nullable use case is mocked with just value then expected value should be returned`() {
         // GIVEN
-        mockUseCaseNullable.everyExecuteNullable(argsNullable) { Flowable.just(expectedResult) }
+        mockUseCaseNullable.mockExecuteNullable(argsNullable) { Flowable.just(expectedResult) }
 
         // WHEN
         val result = executeNullableAndReturnResult()
@@ -69,7 +69,7 @@ class FlowableUseCaseMethodsTests : BaseTest() {
     @Test
     fun `when nullable use case is mocked with just value and without args then expected value should be returned`() {
         // GIVEN
-        mockUseCaseNullable.everyExecuteNullable { Flowable.just(expectedResult) }
+        mockUseCaseNullable.mockExecuteNullable { Flowable.just(expectedResult) }
 
         // WHEN
         val result = executeNullableAndReturnResult()
@@ -81,7 +81,7 @@ class FlowableUseCaseMethodsTests : BaseTest() {
     @Test
     fun `when nullable use case is mocked with null value then expected value should be returned`() {
         // GIVEN
-        mockUseCaseNullable.everyExecuteNullable(null) { Flowable.just(expectedResult) }
+        mockUseCaseNullable.mockExecuteNullable(null) { Flowable.just(expectedResult) }
 
         // WHEN
         val result = executeNullAndReturnResult()

--- a/rx-usecases-test/src/test/java/com/thefuntasty/mvvm/rxusecases/test/MaybeUseCaseMethodsTests.kt
+++ b/rx-usecases-test/src/test/java/com/thefuntasty/mvvm/rxusecases/test/MaybeUseCaseMethodsTests.kt
@@ -33,7 +33,7 @@ class MaybeUseCaseMethodsTests : BaseTest() {
     @Test
     fun `when use case is mocked with just value then expected value should be returned`() {
         // GIVEN
-        mockUseCase.everyExecute(args) { Maybe.just(expectedResult) }
+        mockUseCase.mockExecute(args) { Maybe.just(expectedResult) }
 
         // WHEN
         val result = executeAndReturnResult()
@@ -45,7 +45,7 @@ class MaybeUseCaseMethodsTests : BaseTest() {
     @Test
     fun `when use case is mocked with just value and without args then expected value should be returned`() {
         // GIVEN
-        mockUseCase.everyExecute { Maybe.just(expectedResult) }
+        mockUseCase.mockExecute { Maybe.just(expectedResult) }
 
         // WHEN
         val result = executeAndReturnResult()
@@ -57,7 +57,7 @@ class MaybeUseCaseMethodsTests : BaseTest() {
     @Test
     fun `when nullable use case is mocked with just value then expected value should be returned`() {
         // GIVEN
-        mockUseCaseNullable.everyExecuteNullable(argsNullable) { Maybe.just(expectedResult) }
+        mockUseCaseNullable.mockExecuteNullable(argsNullable) { Maybe.just(expectedResult) }
 
         // WHEN
         val result = executeNullableAndReturnResult()
@@ -69,7 +69,7 @@ class MaybeUseCaseMethodsTests : BaseTest() {
     @Test
     fun `when nullable use case is mocked with just value and without args then expected value should be returned`() {
         // GIVEN
-        mockUseCaseNullable.everyExecuteNullable { Maybe.just(expectedResult) }
+        mockUseCaseNullable.mockExecuteNullable { Maybe.just(expectedResult) }
 
         // WHEN
         val result = executeNullableAndReturnResult()
@@ -81,7 +81,7 @@ class MaybeUseCaseMethodsTests : BaseTest() {
     @Test
     fun `when nullable use case is mocked with null value then expected value should be returned`() {
         // GIVEN
-        mockUseCaseNullable.everyExecuteNullable(null) { Maybe.just(expectedResult) }
+        mockUseCaseNullable.mockExecuteNullable(null) { Maybe.just(expectedResult) }
 
         // WHEN
         val result = executeNullAndReturnResult()

--- a/rx-usecases-test/src/test/java/com/thefuntasty/mvvm/rxusecases/test/ObservableUseCaseMethodsTests.kt
+++ b/rx-usecases-test/src/test/java/com/thefuntasty/mvvm/rxusecases/test/ObservableUseCaseMethodsTests.kt
@@ -33,7 +33,7 @@ class ObservableUseCaseMethodsTests : BaseTest() {
     @Test
     fun `when use case is mocked with just value then expected value should be returned`() {
         // GIVEN
-        mockUseCase.everyExecute(args) { Observable.just(expectedResult) }
+        mockUseCase.mockExecute(args) { Observable.just(expectedResult) }
 
         // WHEN
         val result = executeAndReturnResult()
@@ -45,7 +45,7 @@ class ObservableUseCaseMethodsTests : BaseTest() {
     @Test
     fun `when use case is mocked with just value and without args then expected value should be returned`() {
         // GIVEN
-        mockUseCase.everyExecute { Observable.just(expectedResult) }
+        mockUseCase.mockExecute { Observable.just(expectedResult) }
 
         // WHEN
         val result = executeAndReturnResult()
@@ -57,7 +57,7 @@ class ObservableUseCaseMethodsTests : BaseTest() {
     @Test
     fun `when nullable use case is mocked with just value then expected value should be returned`() {
         // GIVEN
-        mockUseCaseNullable.everyExecuteNullable(argsNullable) { Observable.just(expectedResult) }
+        mockUseCaseNullable.mockExecuteNullable(argsNullable) { Observable.just(expectedResult) }
 
         // WHEN
         val result = executeNullableAndReturnResult()
@@ -69,7 +69,7 @@ class ObservableUseCaseMethodsTests : BaseTest() {
     @Test
     fun `when nullable use case is mocked with just value and without args then expected value should be returned`() {
         // GIVEN
-        mockUseCaseNullable.everyExecuteNullable { Observable.just(expectedResult) }
+        mockUseCaseNullable.mockExecuteNullable { Observable.just(expectedResult) }
 
         // WHEN
         val result = executeNullableAndReturnResult()
@@ -81,7 +81,7 @@ class ObservableUseCaseMethodsTests : BaseTest() {
     @Test
     fun `when nullable use case is mocked with null value then expected value should be returned`() {
         // GIVEN
-        mockUseCaseNullable.everyExecuteNullable(null) { Observable.just(expectedResult) }
+        mockUseCaseNullable.mockExecuteNullable(null) { Observable.just(expectedResult) }
 
         // WHEN
         val result = executeNullAndReturnResult()

--- a/rx-usecases-test/src/test/java/com/thefuntasty/mvvm/rxusecases/test/SingleUseCaseMethodsTests.kt
+++ b/rx-usecases-test/src/test/java/com/thefuntasty/mvvm/rxusecases/test/SingleUseCaseMethodsTests.kt
@@ -33,7 +33,7 @@ class SingleUseCaseMethodsTests : BaseTest() {
     @Test
     fun `when use case is mocked with just value then expected value should be returned`() {
         // GIVEN
-        mockUseCase.everyExecute(args) { Single.just(expectedResult) }
+        mockUseCase.mockExecute(args) { Single.just(expectedResult) }
 
         // WHEN
         val result = executeAndReturnResult()
@@ -45,7 +45,7 @@ class SingleUseCaseMethodsTests : BaseTest() {
     @Test
     fun `when use case is mocked with just value and without args then expected value should be returned`() {
         // GIVEN
-        mockUseCase.everyExecute { Single.just(expectedResult) }
+        mockUseCase.mockExecute { Single.just(expectedResult) }
 
         // WHEN
         val result = executeAndReturnResult()
@@ -57,7 +57,7 @@ class SingleUseCaseMethodsTests : BaseTest() {
     @Test
     fun `when nullable use case is mocked with just value then expected value should be returned`() {
         // GIVEN
-        mockUseCaseNullable.everyExecuteNullable(argsNullable) { Single.just(expectedResult) }
+        mockUseCaseNullable.mockExecuteNullable(argsNullable) { Single.just(expectedResult) }
 
         // WHEN
         val result = executeNullableAndReturnResult()
@@ -69,7 +69,7 @@ class SingleUseCaseMethodsTests : BaseTest() {
     @Test
     fun `when nullable use case is mocked with just value and without args then expected value should be returned`() {
         // GIVEN
-        mockUseCaseNullable.everyExecuteNullable { Single.just(expectedResult) }
+        mockUseCaseNullable.mockExecuteNullable { Single.just(expectedResult) }
 
         // WHEN
         val result = executeNullableAndReturnResult()
@@ -81,7 +81,7 @@ class SingleUseCaseMethodsTests : BaseTest() {
     @Test
     fun `when nullable use case is mocked with null value then expected value should be returned`() {
         // GIVEN
-        mockUseCaseNullable.everyExecuteNullable(null) { Single.just(expectedResult) }
+        mockUseCaseNullable.mockExecuteNullable(null) { Single.just(expectedResult) }
 
         // WHEN
         val result = executeNullAndReturnResult()


### PR DESCRIPTION
This was not implemented in https://github.com/thefuntasty/mvvm-android/pull/103