### PR TITLE
6.x: Rename coroutineScope, refactor BaseComponent lifecycle

### DIFF
--- a/compose/src/main/java/app/futured/arkitekt/compose/BaseViewModel.kt
+++ b/compose/src/main/java/app/futured/arkitekt/compose/BaseViewModel.kt
@@ -10,6 +10,6 @@ import kotlinx.coroutines.Job
 abstract class BaseViewModel<S : ViewState> :
     BaseCoreViewModel<S>(),
     CoroutineScopeOwner {
-    override val coroutineScope: CoroutineScope = viewModelScope
+    override val useCaseScope: CoroutineScope = viewModelScope
     override val useCaseJobPool: MutableMap<Any, Job> = mutableMapOf()
 }

--- a/core-test/src/main/java/app/futured/arkitekt/core/test/internal/CoroutineScopeRule.kt
+++ b/core-test/src/main/java/app/futured/arkitekt/core/test/internal/CoroutineScopeRule.kt
@@ -19,7 +19,7 @@ class CoroutineScopeRule : TestRule {
     class TestCoroutineScopeOwner : CoroutineScopeOwner {
         val testDispatcher = UnconfinedTestDispatcher()
 
-        override val coroutineScope = TestScope(testDispatcher)
+        override val useCaseScope = TestScope(testDispatcher)
         override val useCaseJobPool: MutableMap<Any, Job> = mutableMapOf()
 
         override fun getWorkerDispatcher(): CoroutineDispatcher = testDispatcher

--- a/core-test/src/main/java/app/futured/arkitekt/core/viewmodel/ViewModelTest.kt
+++ b/core-test/src/main/java/app/futured/arkitekt/core/viewmodel/ViewModelTest.kt
@@ -65,12 +65,14 @@ open class ViewModelTest {
      * Swap background android executor with the one that executes task synchronously.
      * It allows to work with the live data.
      */
-    @get:Rule val instantTaskExecutorRule = InstantTaskExecutorRule()
+    @get:Rule
+    val instantTaskExecutorRule = InstantTaskExecutorRule()
 
     /**
      * Swap coroutine dispatcher with the one that is executed immediately.
      * It allows to work with the coroutines.
      */
     @ExperimentalCoroutinesApi
-    @get:Rule var coroutineScopeRule = CoroutineScopeRule()
+    @get:Rule
+    var coroutineScopeRule = CoroutineScopeRule()
 }

--- a/cr-usecases-test/src/test/java/app/futured/arkitekt/crusecases/test/CoroutineScopeOwnerTest.kt
+++ b/cr-usecases-test/src/test/java/app/futured/arkitekt/crusecases/test/CoroutineScopeOwnerTest.kt
@@ -79,13 +79,13 @@ class CoroutineScopeOwnerTest {
                 onSuccess { executionCount++ }
                 onError { fail("Exception thrown where shouldn't") }
             }
-            coroutineScope.advanceTimeByCompat(500)
+            useCaseScope.advanceTimeByCompat(500)
 
             testUseCase.execute(1) {
                 onSuccess { executionCount++ }
                 onError { fail("Exception thrown where shouldn't") }
             }
-            coroutineScope.advanceTimeByCompat(1000)
+            useCaseScope.advanceTimeByCompat(1000)
         }
 
         assertEquals(1, executionCount)
@@ -99,7 +99,7 @@ class CoroutineScopeOwnerTest {
             TestFailureUseCase().execute(IllegalStateException()) {
                 onError { resultError = it }
             }
-            coroutineScope.advanceTimeByCompat(1000)
+            useCaseScope.advanceTimeByCompat(1000)
         }
 
         assertNotNull(resultError)
@@ -115,7 +115,7 @@ class CoroutineScopeOwnerTest {
                 onNext { resultList.add(it) }
                 onError { fail("Exception thrown where shouldn't") }
             }
-            coroutineScope.advanceTimeByCompat(10000)
+            useCaseScope.advanceTimeByCompat(10000)
         }
 
         assertEquals(testingList, resultList)
@@ -131,7 +131,7 @@ class CoroutineScopeOwnerTest {
                 onError { fail("Exception thrown where shouldn't") }
                 onComplete { completed = true }
             }
-            coroutineScope.advanceTimeByCompat(10000)
+            useCaseScope.advanceTimeByCompat(10000)
         }
 
         assertEquals(true, completed)
@@ -146,7 +146,7 @@ class CoroutineScopeOwnerTest {
                 onError { resultError = it }
                 onComplete { fail("onComplete called where shouldn't") }
             }
-            coroutineScope.advanceTimeByCompat(1000)
+            useCaseScope.advanceTimeByCompat(1000)
         }
 
         assertNotNull(resultError)
@@ -158,10 +158,10 @@ class CoroutineScopeOwnerTest {
         var result: Result<Int>? = null
 
         with(testOwner) {
-            coroutineScope.launch {
+            useCaseScope.launch {
                 result = testUseCase.execute(1)
             }
-            coroutineScope.advanceTimeByCompat(10000)
+            useCaseScope.advanceTimeByCompat(10000)
         }
 
         assertEquals(Result.success(1), result)
@@ -172,10 +172,10 @@ class CoroutineScopeOwnerTest {
         var result: Result<Unit>? = null
 
         with(testOwner) {
-            coroutineScope.launch {
+            useCaseScope.launch {
                 result = TestFailureUseCase().execute(IllegalStateException())
             }
-            coroutineScope.advanceTimeByCompat(10000)
+            useCaseScope.advanceTimeByCompat(10000)
         }
 
         assertTrue(result?.isFailure == true)
@@ -187,10 +187,10 @@ class CoroutineScopeOwnerTest {
         var result: Result<Unit>? = null
 
         with(testOwner) {
-            coroutineScope.launch {
+            useCaseScope.launch {
                 result = TestFailureUseCase().execute(CancellationException())
             }
-            coroutineScope.advanceTimeByCompat(10000)
+            useCaseScope.advanceTimeByCompat(10000)
         }
 
         assertNull(result)
@@ -202,14 +202,14 @@ class CoroutineScopeOwnerTest {
         var result: Result<Int>? = null
 
         with(testOwner) {
-            coroutineScope.launch {
+            useCaseScope.launch {
                 testUseCase.execute(1)
                 fail("Execute should be cancelled")
             }
-            coroutineScope.launch {
+            useCaseScope.launch {
                 result = testUseCase.execute(1)
             }
-            coroutineScope.advanceTimeByCompat(10000)
+            useCaseScope.advanceTimeByCompat(10000)
         }
 
         assertEquals(Result.success(1), result)
@@ -222,13 +222,13 @@ class CoroutineScopeOwnerTest {
         var result2: Result<Int>? = null
 
         with(testOwner) {
-            coroutineScope.launch {
+            useCaseScope.launch {
                 result1 = testUseCase.execute(1, cancelPrevious = false)
             }
-            coroutineScope.launch {
+            useCaseScope.launch {
                 result2 = testUseCase.execute(2, cancelPrevious = false)
             }
-            coroutineScope.advanceTimeByCompat(10000)
+            useCaseScope.advanceTimeByCompat(10000)
         }
 
         assertEquals(Result.success(1), result1)
@@ -242,7 +242,7 @@ class CoroutineScopeOwnerTest {
         val ownerDispatcher = StandardTestDispatcher()
         val ownerScope = TestScope(ownerDispatcher)
         val owner = object : CoroutineScopeOwner {
-            override val coroutineScope: CoroutineScope = ownerScope
+            override val useCaseScope: CoroutineScope = ownerScope
             override val useCaseJobPool: MutableMap<Any, Job> = mutableMapOf()
             override fun getWorkerDispatcher() = ownerDispatcher
             override fun defaultErrorHandler(exception: Throwable) {
@@ -267,7 +267,7 @@ class CoroutineScopeOwnerTest {
         val ownerDispatcher = StandardTestDispatcher()
         val ownerScope = TestScope(ownerDispatcher)
         val owner = object : CoroutineScopeOwner {
-            override val coroutineScope: CoroutineScope = ownerScope
+            override val useCaseScope: CoroutineScope = ownerScope
             override val useCaseJobPool: MutableMap<Any, Job> = mutableMapOf()
             override fun getWorkerDispatcher() = ownerDispatcher
             override fun defaultErrorHandler(exception: Throwable) {
@@ -292,7 +292,7 @@ class CoroutineScopeOwnerTest {
         val ownerDispatcher = StandardTestDispatcher()
         val ownerScope = TestScope(ownerDispatcher)
         val owner = object : CoroutineScopeOwner {
-            override val coroutineScope: CoroutineScope = ownerScope
+            override val useCaseScope: CoroutineScope = ownerScope
             override val useCaseJobPool: MutableMap<Any, Job> = mutableMapOf()
             override fun getWorkerDispatcher() = ownerDispatcher
             override fun defaultErrorHandler(exception: Throwable) {
@@ -320,7 +320,7 @@ class CoroutineScopeOwnerTest {
             TestFailureUseCase().execute(IllegalStateException()) {
                 onError { resultError = it }
             }
-            coroutineScope.advanceTimeByCompat(10000)
+            useCaseScope.advanceTimeByCompat(10000)
         }
 
         assertTrue(resultError is IllegalStateException)
@@ -337,7 +337,7 @@ class CoroutineScopeOwnerTest {
             TestFailureFlowUseCase().execute(IllegalStateException()) {
                 onError { resultError = it }
             }
-            coroutineScope.advanceTimeByCompat(10000)
+            useCaseScope.advanceTimeByCompat(10000)
         }
 
         assertTrue(resultError is IllegalStateException)

--- a/cr-usecases-test/src/test/java/app/futured/arkitekt/crusecases/test/FlowUseCaseTests.kt
+++ b/cr-usecases-test/src/test/java/app/futured/arkitekt/crusecases/test/FlowUseCaseTests.kt
@@ -114,7 +114,7 @@ class FlowUseCaseTests {
                 onNext { result = it }
                 onError { result = errorValue }
             }
-            coroutineScope.advanceUntilIdle()
+            useCaseScope.advanceUntilIdle()
         }
         return result
     }
@@ -126,7 +126,7 @@ class FlowUseCaseTests {
                 onNext { result = it }
                 onError { result = errorValue }
             }
-            coroutineScope.advanceUntilIdle()
+            useCaseScope.advanceUntilIdle()
         }
         return result
     }
@@ -138,7 +138,7 @@ class FlowUseCaseTests {
                 onNext { result = it }
                 onError { result = errorValue }
             }
-            coroutineScope.advanceUntilIdle()
+            useCaseScope.advanceUntilIdle()
         }
         return result
     }

--- a/cr-usecases-test/src/test/java/app/futured/arkitekt/crusecases/test/TestCoroutineScopeOwner.kt
+++ b/cr-usecases-test/src/test/java/app/futured/arkitekt/crusecases/test/TestCoroutineScopeOwner.kt
@@ -11,7 +11,7 @@ import kotlinx.coroutines.test.TestScope
 class TestCoroutineScopeOwner : CoroutineScopeOwner {
     val testDispatcher = StandardTestDispatcher()
 
-    override val coroutineScope = TestScope(testDispatcher)
+    override val useCaseScope = TestScope(testDispatcher)
     override val useCaseJobPool: MutableMap<Any, Job> = mutableMapOf()
 
     override fun getWorkerDispatcher(): CoroutineDispatcher = testDispatcher

--- a/cr-usecases-test/src/test/java/app/futured/arkitekt/crusecases/test/UseCaseTests.kt
+++ b/cr-usecases-test/src/test/java/app/futured/arkitekt/crusecases/test/UseCaseTests.kt
@@ -130,7 +130,7 @@ class UseCaseTests {
                 onSuccess { result = it }
                 onError { result = errorValue }
             }
-            coroutineScope.advanceUntilIdle()
+            useCaseScope.advanceUntilIdle()
         }
         return result
     }
@@ -142,7 +142,7 @@ class UseCaseTests {
                 onSuccess { result = it }
                 onError { result = errorValue }
             }
-            coroutineScope.advanceUntilIdle()
+            useCaseScope.advanceUntilIdle()
         }
         return result
     }
@@ -154,7 +154,7 @@ class UseCaseTests {
                 onSuccess { result = it }
                 onError { result = errorValue }
             }
-            coroutineScope.advanceUntilIdle()
+            useCaseScope.advanceUntilIdle()
         }
         return result
     }

--- a/cr-usecases/src/commonMain/kotlin/app/futured/arkitekt/crusecases/CoroutineScopeOwner.kt
+++ b/cr-usecases/src/commonMain/kotlin/app/futured/arkitekt/crusecases/CoroutineScopeOwner.kt
@@ -12,14 +12,14 @@ import kotlinx.coroutines.launch
 /**
  * This interface gives your class ability to execute [UseCase] and [FlowUseCase] Coroutine use cases.
  * You may find handy to implement this interface in custom Presenters, ViewHolders etc.
- * It is your responsibility to cancel [coroutineScope] when all running tasks should be stopped.
+ * It is your responsibility to cancel [useCaseScope] when all running tasks should be stopped.
  */
 interface CoroutineScopeOwner {
     /**
      * [CoroutineScope] scope used to execute coroutine based use cases. It is your responsibility to cancel it when all running
      * tasks should be stopped
      */
-    val coroutineScope: CoroutineScope
+    val useCaseScope: CoroutineScope
 
     /**
      * Map of [Job] objects used to hold and cancel existing run of any [FlowUseCase] instance.
@@ -32,7 +32,7 @@ interface CoroutineScopeOwner {
     fun getWorkerDispatcher() = Dispatchers.IO
 
     /**
-     * Launch suspend [block] in [coroutineScope].
+     * Launch suspend [block] in [useCaseScope].
      *
      * Encapsulates this call with try catch block and when an exception is thrown
      * then it is logged in [UseCaseErrorHandler.globalOnErrorLogger] and handled by [defaultErrorHandler].
@@ -42,7 +42,7 @@ interface CoroutineScopeOwner {
      * [CancellationException] (e.g. when [Result.getOrCancel] is used).
      */
     fun launchWithHandler(block: suspend CoroutineScope.() -> Unit) {
-        coroutineScope.launch {
+        useCaseScope.launch {
             try {
                 block()
             } catch (exception: CancellationException) {

--- a/cr-usecases/src/commonMain/kotlin/app/futured/arkitekt/crusecases/FlowUseCaseExecution.kt
+++ b/cr-usecases/src/commonMain/kotlin/app/futured/arkitekt/crusecases/FlowUseCaseExecution.kt
@@ -71,7 +71,7 @@ private fun <ARGS, T : Any?> FlowUseCase<ARGS, T>.internalExecute(
                     }
                 }
             }.catch { /* handled in onCompletion */ }
-            .launchIn(coroutineScopeOwner.coroutineScope)
+            .launchIn(coroutineScopeOwner.useCaseScope)
 }
 
 

--- a/cr-usecases/src/commonMain/kotlin/app/futured/arkitekt/crusecases/ResultExt.kt
+++ b/cr-usecases/src/commonMain/kotlin/app/futured/arkitekt/crusecases/ResultExt.kt
@@ -1,0 +1,24 @@
+package app.futured.arkitekt.crusecases
+
+import kotlinx.coroutines.CancellationException
+
+/**
+ * Returns the encapsulated value if this instance represents `success` or
+ * throws [CancellationException] with [Throwable] as its cause if it is `error`.
+ *
+ * This method should be used in the case when you want to safely cancel your coroutine from inside.
+ *
+ * If [Throwable] is not [CancellationException] then [doBeforeThrow] is called before throw.
+ */
+inline fun <VALUE> Result<VALUE>.getOrCancel(doBeforeThrow: (Throwable) -> Unit = {}): VALUE = fold(
+    onSuccess = { value -> value },
+    onFailure = { exception ->
+        if (exception !is CancellationException) {
+            doBeforeThrow(exception)
+        }
+        throw CancellationException(
+            message = "Cancellation caused by $exception",
+            cause = exception,
+        )
+    },
+)

--- a/cr-usecases/src/commonMain/kotlin/app/futured/arkitekt/crusecases/UseCaseExecution.kt
+++ b/cr-usecases/src/commonMain/kotlin/app/futured/arkitekt/crusecases/UseCaseExecution.kt
@@ -71,7 +71,7 @@ suspend fun <ARGS, T : Any?> UseCase<ARGS, T>.execute(
     }
     return try {
         val newDeferred =
-            coroutineScopeOwner.coroutineScope
+            coroutineScopeOwner.useCaseScope
                 .async(coroutineScopeOwner.getWorkerDispatcher(), CoroutineStart.LAZY) {
                     build(args)
                 }.also { coroutineScopeOwner.useCaseJobPool[this] = it }
@@ -122,11 +122,11 @@ private fun <ARGS, T : Any?> UseCase<ARGS, T>.internalExecute(
 
     useCaseConfig.onStart()
     coroutineScopeOwner.useCaseJobPool[this] =
-        coroutineScopeOwner.coroutineScope
+        coroutineScopeOwner.useCaseScope
             .async(context = coroutineScopeOwner.getWorkerDispatcher(), start = CoroutineStart.LAZY) {
                 build(args)
             }.also {
-                coroutineScopeOwner.coroutineScope.launch(Dispatchers.Main) {
+                coroutineScopeOwner.useCaseScope.launch(Dispatchers.Main) {
                     try {
                         useCaseConfig.onSuccess(it.await())
                     } catch (_: CancellationException) {

--- a/cr-usecases/src/commonMain/kotlin/app/futured/arkitekt/crusecases/utils/ThrowableExtensions.kt
+++ b/cr-usecases/src/commonMain/kotlin/app/futured/arkitekt/crusecases/utils/ThrowableExtensions.kt
@@ -3,7 +3,7 @@ package app.futured.arkitekt.crusecases.utils
 /**
  * Returns a root cause of this exception or null if there is no
  */
-val Throwable.rootCause: Throwable?
+internal val Throwable.rootCause: Throwable?
     get() {
         var currentCause: Throwable? = cause
         while (currentCause?.cause != null) {

--- a/decompose/src/commonMain/kotlin/app/futured/arkitekt/decompose/presentation/BaseComponent.kt
+++ b/decompose/src/commonMain/kotlin/app/futured/arkitekt/decompose/presentation/BaseComponent.kt
@@ -2,6 +2,7 @@ package app.futured.arkitekt.decompose.presentation
 
 import com.arkivanov.decompose.GenericComponentContext
 import com.arkivanov.essenty.lifecycle.doOnDestroy
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.channels.Channel
@@ -10,7 +11,6 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.receiveAsFlow
-import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 
@@ -22,26 +22,27 @@ import kotlinx.coroutines.launch
  * @param E The type of the UI events.
  * @param componentContext The context of the component.
  * @param defaultState The default Component state.
+ * @param lifecycleScope The coroutine scope tied to the lifecycle of the component.
+ * It will be automatically canceled when component's lifecycle is destroyed.
+ * You can inject your own scope for use in tests.
  */
 abstract class BaseComponent<VS : Any, E : Any>(
     componentContext: GenericComponentContext<*>,
     private val defaultState: VS,
+    open val lifecycleScope: CoroutineScope = MainScope(),
 ) {
+
+    init {
+        componentContext.lifecycle.doOnDestroy {
+            eventChannel.close()
+            lifecycleScope.cancel()
+        }
+    }
+
     /**
      * An internal state of the component of type [VS].
      */
     protected val componentState: MutableStateFlow<VS> = MutableStateFlow(defaultState)
-
-    // region Lifecycle
-
-    /**
-     * The coroutine scope tied to the lifecycle of the component.
-     * It is cancelled when the component is destroyed.
-     */
-    protected val componentCoroutineScope =
-        MainScope().also { scope ->
-            componentContext.lifecycle.doOnDestroy { scope.cancel() }
-        }
 
     /**
      * Converts a [Flow] of component states to a [StateFlow].
@@ -50,24 +51,28 @@ abstract class BaseComponent<VS : Any, E : Any>(
      * @return A [StateFlow] emitting the values of the [Flow].
      */
     protected fun Flow<VS>.asStateFlow(started: SharingStarted = SharingStarted.Lazily) =
-        stateIn(componentCoroutineScope, started, defaultState)
-
-    // endregion
+        stateIn(lifecycleScope, started, defaultState)
 
     // region UI events
 
     /**
-     * Channel for sending UI events.
+     * Backing channel for UI events.
+     *
+     * Uses [Channel.BUFFERED] (capacity 64 by default) so producers don't
+     * have to suspend under normal circumstances, while still retaining
+     * events for a collector that hasn't subscribed yet.
      */
-    private val uiEventChannel = Channel<E>(Channel.BUFFERED)
+    private val eventChannel = Channel<E>(Channel.BUFFERED)
 
     /**
-     * Flow of UI events.
+     * Stream of one-shot UI events.
+     *
+     * Intended to be collected by a **single** observer (typically the
+     * current screen). Each emitted event is received exactly once — on
+     * re-subscription after a configuration change, any buffered events
+     * are delivered to the new collector.
      */
-    val events: Flow<E> =
-        uiEventChannel
-            .receiveAsFlow()
-            .shareIn(componentCoroutineScope, SharingStarted.Lazily)
+    val events: Flow<E> = eventChannel.receiveAsFlow()
 
     // endregion
 
@@ -79,8 +84,8 @@ abstract class BaseComponent<VS : Any, E : Any>(
      * @param event The event to send.
      */
     protected fun sendUiEvent(event: E) {
-        componentCoroutineScope.launch {
-            uiEventChannel.send(event)
+        lifecycleScope.launch {
+            eventChannel.send(event)
         }
     }
 

--- a/example/src/test/java/app/futured/arkitekt/sample/ui/form/FormViewModelTest.kt
+++ b/example/src/test/java/app/futured/arkitekt/sample/ui/form/FormViewModelTest.kt
@@ -44,7 +44,7 @@ class FormViewModelTest : ViewModelTest() {
 
     private fun awaitInit() =
         runBlocking {
-            viewModel.coroutineScope.coroutineContext[Job]!!
+            viewModel.useCaseScope.coroutineContext[Job]!!
                 .children
                 .toList()
                 .forEach { it.join() }

--- a/example/src/test/java/app/futured/arkitekt/sample/ui/login/fragment/LoginViewModelTest.kt
+++ b/example/src/test/java/app/futured/arkitekt/sample/ui/login/fragment/LoginViewModelTest.kt
@@ -51,7 +51,7 @@ class LoginViewModelTest : ViewModelTest() {
 
     // Waits for all coroutines launched during ViewModel.init to complete.
     private fun awaitInit() = runBlocking {
-        viewModel.coroutineScope.coroutineContext[Job]!!.children.toList().forEach { it.join() }
+        viewModel.useCaseScope.coroutineContext[Job]!!.children.toList().forEach { it.join() }
     }
 
     @Test


### PR DESCRIPTION
## Summary
API polish for 6.x: renames `coroutineScope` to `useCaseScope` in `CoroutineScopeOwner` for clarity, refactors `BaseComponent` to expose an injectable `lifecycleScope`, and adds a `Result.getOrCancel()` extension for cancelling coroutines on failure.

## Changes
- `CoroutineScopeOwner.coroutineScope` → `useCaseScope` (breaking rename — scope is for use cases, not general-purpose use)
- `BaseComponent.componentCoroutineScope` → `lifecycleScope` constructor parameter, injectable for tests
- `events` flow simplified: removed `shareIn` wrapper, now bare `receiveAsFlow()` (single-collector channel)
- `Result.getOrCancel()` — new extension that converts a failure into `CancellationException`
- `Throwable.rootCause` made `internal`

## Notes
**Breaking changes:**
- `CoroutineScopeOwner` implementations must rename `coroutineScope` → `useCaseScope`
- `BaseComponent` subclasses using `componentCoroutineScope` must switch to `lifecycleScope`