### PR TITLE
6.x: Add decompose-test module

### DIFF
--- a/decompose-test/build.gradle.kts
+++ b/decompose-test/build.gradle.kts
@@ -4,8 +4,6 @@ import com.vanniktech.maven.publish.KotlinMultiplatform
 plugins {
     id("com.android.kotlin.multiplatform.library")
     id("org.jetbrains.kotlin.multiplatform")
-    id("org.jetbrains.kotlin.plugin.compose")
-    id("org.jetbrains.kotlin.plugin.serialization")
     id(Deps.Plugins.mavenPublish)
 }
 
@@ -13,7 +11,7 @@ kotlin {
     jvmToolchain(17)
 
     android {
-        namespace = "app.futured.arkitekt.decompose.android"
+        namespace = "app.futured.arkitekt.decompose.test"
         compileSdk = ProjectSettings.compileSdk
         minSdk = ProjectSettings.minSdk
     }
@@ -23,26 +21,19 @@ kotlin {
     iosSimulatorArm64()
 
     sourceSets {
-        commonMain  {
+        commonMain {
             dependencies {
-                implementation(Deps.Decompose.core)
-                implementation(Deps.Decompose.essentyLifecycle)
-                implementation(Deps.Kotlin.coroutines)
-                implementation(Deps.Compose.jetbrainsRuntime)
-                implementation(Deps.Serialization.core)
-            }
-        }
-
-        commonTest {
-            dependencies {
-                implementation(project(":decompose-test"))
+                api(project(":decompose"))
+                api(Deps.Decompose.core)
+                api(Deps.Decompose.essentyLifecycle)
+                api(kotlin("test"))
+                api(Deps.Test.testCoroutines)
             }
         }
 
         androidMain {
             dependencies {
-                implementation(project.dependencies.platform(Deps.Compose.bom))
-                implementation(Deps.Compose.runtime)
+                api(kotlin("test-junit"))
             }
         }
     }
@@ -58,11 +49,11 @@ mavenPublishing {
     )
     coordinates(
         groupId = ProjectSettings.group,
-        artifactId = "decompose",
+        artifactId = "decompose-test",
     )
     pom {
-        name = "Arkitekt Decompose"
-        description = "KMP Decompose integration for Arkitekt framework"
+        name = "Arkitekt Decompose Test"
+        description = "Test utilities for Arkitekt Decompose module"
         url = "https://github.com/futuredapp/arkitekt"
         licenses {
             license {

--- a/decompose-test/src/commonMain/kotlin/app/futured/arkitekt/decompose/test/ComponentTest.kt
+++ b/decompose-test/src/commonMain/kotlin/app/futured/arkitekt/decompose/test/ComponentTest.kt
@@ -1,0 +1,77 @@
+package app.futured.arkitekt.decompose.test
+
+import com.arkivanov.decompose.DefaultComponentContext
+import com.arkivanov.essenty.lifecycle.LifecycleRegistry
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * Contract for [BaseComponent] unit tests in Kotlin Multiplatform.
+ *
+ * Implement via Kotlin class delegation backed by [ComponentTestPreparation].
+ * [setup] and [cleanup] are wired to [BeforeTest] / [AfterTest] and run automatically.
+ *
+ * Sample test:
+ *
+ *     class SampleComponentTest : ComponentTest by ComponentTestPreparation() {
+ *
+ *         @Test
+ *         fun `example test`() = runComponentTest {
+ *             lifecycleRegistry.create()
+ *             val component = SampleComponent(componentContext, testScope)
+ *             // assertions...
+ *         }
+ *     }
+ */
+interface ComponentTest {
+    /**
+     * [TestScope] shared by the test body and [runComponentTest].
+     */
+    val testScope: TestScope
+
+    /**
+     * [TestDispatcher] installed as [kotlinx.coroutines.Dispatchers.Main] during each test.
+     */
+    val testDispatcher: TestDispatcher
+
+    /**
+     * [LifecycleRegistry] that drives the [componentContext] lifecycle.
+     * Call [com.arkivanov.essenty.lifecycle.create] inside a test to start the component lifecycle.
+     */
+    val lifecycleRegistry: LifecycleRegistry
+
+    /**
+     * [DefaultComponentContext] backed by [lifecycleRegistry]. Pass this to the component under test.
+     */
+    val componentContext: DefaultComponentContext
+
+    /**
+     * Sets [testDispatcher] as [kotlinx.coroutines.Dispatchers.Main]. Called automatically under [BeforeTest].
+     */
+    @BeforeTest
+    fun setup()
+
+    /**
+     * Destroys [lifecycleRegistry] if still alive and resets [kotlinx.coroutines.Dispatchers.Main]. Called automatically under [AfterTest].
+     */
+    @AfterTest
+    fun cleanup()
+}
+
+private val DEFAULT_TIMEOUT = 60.seconds
+
+/**
+ * Runs [testBody] inside [testScope] via [kotlinx.coroutines.test.runTest].
+ *
+ * @param timeout Maximum duration before the test times out. Defaults to 60 seconds.
+ * @param testBody Suspend test body executed with [TestScope] as the receiver.
+ */
+fun ComponentTest.runComponentTest(
+    timeout: Duration = DEFAULT_TIMEOUT,
+    testBody: suspend TestScope.() -> Unit,
+) = testScope.runTest(timeout, testBody)

--- a/decompose-test/src/commonMain/kotlin/app/futured/arkitekt/decompose/test/ComponentTestPreparation.kt
+++ b/decompose-test/src/commonMain/kotlin/app/futured/arkitekt/decompose/test/ComponentTestPreparation.kt
@@ -1,0 +1,38 @@
+package app.futured.arkitekt.decompose.test
+
+import com.arkivanov.decompose.DefaultComponentContext
+import com.arkivanov.essenty.lifecycle.Lifecycle
+import com.arkivanov.essenty.lifecycle.LifecycleRegistry
+import com.arkivanov.essenty.lifecycle.destroy
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+
+/**
+ * Default [ComponentTest] implementation intended for Kotlin class delegation.
+ *
+ * Open for subclassing to add project-specific fixtures or helpers.
+ */
+open class ComponentTestPreparation : ComponentTest {
+
+    override val testScope = TestScope()
+    override val testDispatcher = StandardTestDispatcher(testScope.testScheduler)
+    override val lifecycleRegistry = LifecycleRegistry()
+    override val componentContext = DefaultComponentContext(lifecycleRegistry)
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    override fun setup() {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    override fun cleanup() {
+        if (lifecycleRegistry.state != Lifecycle.State.DESTROYED) {
+            lifecycleRegistry.destroy()
+        }
+        Dispatchers.resetMain()
+    }
+}

--- a/decompose/src/commonTest/kotlin/app/futured/arkitekt/decompose/presentation/BaseComponentTest.kt
+++ b/decompose/src/commonTest/kotlin/app/futured/arkitekt/decompose/presentation/BaseComponentTest.kt
@@ -1,0 +1,190 @@
+package app.futured.arkitekt.decompose.presentation
+
+import app.futured.arkitekt.decompose.test.ComponentTest
+import app.futured.arkitekt.decompose.test.ComponentTestPreparation
+import app.futured.arkitekt.decompose.test.runComponentTest
+import com.arkivanov.decompose.GenericComponentContext
+import com.arkivanov.essenty.lifecycle.create
+import com.arkivanov.essenty.lifecycle.destroy
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.onCompletion
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runCurrent
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+private data class TestState(val value: Int = 0)
+
+private sealed interface TestEvent {
+    data object First : TestEvent
+    data class WithPayload(val n: Int) : TestEvent
+}
+
+private class TestableComponent(
+    componentContext: GenericComponentContext<*>,
+    lifecycleScope: CoroutineScope,
+) : BaseComponent<TestState, TestEvent>(
+    componentContext = componentContext,
+    defaultState = TestState(),
+    lifecycleScope = lifecycleScope,
+) {
+    fun emit(event: TestEvent) = sendUiEvent(event)
+    val state get() = componentState
+}
+
+private fun ComponentTest.createComponent(
+    scope: CoroutineScope = testScope,
+) = TestableComponent(componentContext, scope)
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class BaseComponentTest : ComponentTest by ComponentTestPreparation() {
+
+    // region UI events
+
+    @Test
+    fun `sendUiEvent emits event to collector`() = runComponentTest {
+        lifecycleRegistry.create()
+        val component = createComponent()
+        val received = mutableListOf<TestEvent>()
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            component.events.collect { received.add(it) }
+        }
+
+        component.emit(TestEvent.First)
+        runCurrent()
+
+        assertEquals(listOf<TestEvent>(TestEvent.First), received)
+    }
+
+    @Test
+    fun `sendUiEvent preserves order and payload`() = runComponentTest {
+        lifecycleRegistry.create()
+        val component = createComponent()
+        val received = mutableListOf<TestEvent>()
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            component.events.collect { received.add(it) }
+        }
+
+        component.emit(TestEvent.WithPayload(1))
+        component.emit(TestEvent.WithPayload(2))
+        component.emit(TestEvent.WithPayload(3))
+        runCurrent()
+
+        assertEquals(
+            listOf<TestEvent>(TestEvent.WithPayload(1), TestEvent.WithPayload(2), TestEvent.WithPayload(3)),
+            received,
+        )
+    }
+
+    @Test
+    fun `events are buffered before collection`() = runComponentTest {
+        lifecycleRegistry.create()
+        val component = createComponent()
+
+        component.emit(TestEvent.WithPayload(10))
+        component.emit(TestEvent.WithPayload(20))
+        runCurrent()
+
+        val received = mutableListOf<TestEvent>()
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            component.events.collect { received.add(it) }
+        }
+
+        assertEquals(listOf<TestEvent>(TestEvent.WithPayload(10), TestEvent.WithPayload(20)), received)
+    }
+
+    @Test
+    fun `events are delivered exactly once across re-subscription`() = runComponentTest {
+        lifecycleRegistry.create()
+        val component = createComponent()
+
+        val firstCollector = mutableListOf<TestEvent>()
+        val firstJob = backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            component.events.collect { firstCollector.add(it) }
+        }
+
+        component.emit(TestEvent.WithPayload(1))
+        runCurrent()
+
+        firstJob.cancel()
+
+        val secondCollector = mutableListOf<TestEvent>()
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            component.events.collect { secondCollector.add(it) }
+        }
+
+        component.emit(TestEvent.WithPayload(2))
+        runCurrent()
+
+        assertEquals(listOf<TestEvent>(TestEvent.WithPayload(1)), firstCollector)
+        assertEquals(listOf<TestEvent>(TestEvent.WithPayload(2)), secondCollector)
+    }
+
+    @Test
+    fun `componentState starts with default state`() = runComponentTest {
+        lifecycleRegistry.create()
+        val component = createComponent()
+
+        assertEquals(TestState(), component.state.value)
+    }
+
+    // endregion
+
+    // region Lifecycle
+
+    @Test
+    fun `onDestroy completes the events flow`() = runComponentTest {
+        val scope = CoroutineScope(testDispatcher + Job())
+        val component = createComponent(scope = scope)
+        lifecycleRegistry.create()
+
+        var completed = false
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            component.events
+                .onCompletion { completed = true }
+                .collect { }
+        }
+
+        lifecycleRegistry.destroy()
+
+        assertTrue(completed)
+    }
+
+    @Test
+    fun `onDestroy cancels the lifecycleScope`() = runComponentTest {
+        val scope = CoroutineScope(testDispatcher + Job())
+        createComponent(scope = scope)
+        lifecycleRegistry.create()
+
+        lifecycleRegistry.destroy()
+
+        assertFalse(scope.coroutineContext[Job]!!.isActive)
+    }
+
+    @Test
+    fun `sendUiEvent after destroy is a no-op`() = runComponentTest {
+        val scope = CoroutineScope(testDispatcher + Job())
+        val component = createComponent(scope = scope)
+        lifecycleRegistry.create()
+
+        lifecycleRegistry.destroy()
+        runCurrent()
+
+        val received = mutableListOf<TestEvent>()
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            component.events.collect { received.add(it) }
+        }
+
+        component.emit(TestEvent.First)
+        runCurrent()
+
+        assertTrue(received.isEmpty())
+    }
+
+    // endregion
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -7,6 +7,7 @@ include(
     ":decompose",
     ":decompose-annotation",
     ":decompose-processor",
+    ":decompose-test",
     ":example",
     ":cr-usecases",
     ":arkitekt-lint",


### PR DESCRIPTION
## Summary

Extracts `ComponentTest`, `ComponentTestPreparation`, and `runComponentTest` into a standalone `decompose-test` KMP module so consumers can depend on test utilities as a separate Maven artifact without pulling in test infrastructure from the main `decompose` module.

## Changes

- New `decompose-test` module with `ComponentTest` interface, `ComponentTestPreparation` default implementation, and `runComponentTest` runner — all fully KDoc documented
- `decompose/build.gradle.kts` updated to depend on `:decompose-test` instead of raw `kotlin("test")` + `testCoroutines` in `commonTest`
- `BaseComponentTest` migrated to use the new module
- Module registered in `settings.gradle.kts`

## Notes

`decompose-test` exposes its dependencies via `api()` so consumers get `kotlin-test`, `kotlinx-coroutines-test`, Decompose, and Essenty transitively without extra declarations.