### PR TITLE
Fix incremental factory generation

### DIFF
--- a/cr-usecases/src/commonMain/kotlin/app/futured/arkitekt/crusecases/FlowUseCaseExecution.kt
+++ b/cr-usecases/src/commonMain/kotlin/app/futured/arkitekt/crusecases/FlowUseCaseExecution.kt
@@ -11,8 +11,8 @@ import kotlinx.coroutines.flow.onStart
 
 context(coroutineScopeOwner: CoroutineScopeOwner)
 fun <T : Any?> FlowUseCase<Unit, T>.execute(
-    config: FlowUseCaseConfig.Builder<T, T>.() -> Unit
-) = execute(Unit, config)
+    config: FlowUseCaseConfig.Builder<T, T>.() -> Unit,
+): Unit = execute(Unit, config)
 
 /**
  * Asynchronously executes use case and consumes data from flow on UI thread.

--- a/cr-usecases/src/commonMain/kotlin/app/futured/arkitekt/crusecases/UseCaseExecution.kt
+++ b/cr-usecases/src/commonMain/kotlin/app/futured/arkitekt/crusecases/UseCaseExecution.kt
@@ -16,7 +16,9 @@ import kotlinx.coroutines.launch
  * Coroutine and to set configuration options.
  */
 context(coroutineScopeOwner: CoroutineScopeOwner)
-fun <T : Any?> UseCase<Unit, T>.execute(config: UseCaseConfig.Builder<T>.() -> Unit) = execute(Unit, config)
+fun <T : Any?> UseCase<Unit, T>.execute(
+    config: UseCaseConfig.Builder<T>.() -> Unit,
+): Unit = execute(Unit, config)
 
 /**
  * Asynchronously executes use case and saves it's Deferred. By default, all previous

--- a/decompose-processor/src/jvmMain/kotlin/app/futured/arkitekt/factorygenerator/processor/ComponentFactoryProcessor.kt
+++ b/decompose-processor/src/jvmMain/kotlin/app/futured/arkitekt/factorygenerator/processor/ComponentFactoryProcessor.kt
@@ -11,19 +11,9 @@ import kotlin.reflect.KClass
 class ComponentFactoryProcessor(
     private val codeGenerator: CodeGenerator,
 ) : SymbolProcessor {
-    // KSP may invoke process() in multiple rounds (e.g. when another aggregating processor like
-    // Koin's compiler generates files that trigger a new round). Guard against re-running so we
-    // don't attempt to create files that already exist from round 1.
-    private var invoked = false
-
     override fun process(resolver: Resolver): List<KSAnnotated> {
-        if (invoked) return emptyList()
-        invoked = true
-
         val components: Sequence<KSClassDeclaration> = resolver.findAnnotationsForClass(GenerateFactory::class)
-
         components.forEach { generateComponent(it) }
-
         return emptyList()
     }
 

--- a/decompose-processor/src/jvmMain/kotlin/app/futured/arkitekt/factorygenerator/processor/ComponentFactoryProcessor.kt
+++ b/decompose-processor/src/jvmMain/kotlin/app/futured/arkitekt/factorygenerator/processor/ComponentFactoryProcessor.kt
@@ -11,7 +11,15 @@ import kotlin.reflect.KClass
 class ComponentFactoryProcessor(
     private val codeGenerator: CodeGenerator,
 ) : SymbolProcessor {
+    // KSP may invoke process() in multiple rounds (e.g. when another aggregating processor like
+    // Koin's compiler generates files that trigger a new round). Guard against re-running so we
+    // don't attempt to create files that already exist from round 1.
+    private var invoked = false
+
     override fun process(resolver: Resolver): List<KSAnnotated> {
+        if (invoked) return emptyList()
+        invoked = true
+
         val components: Sequence<KSClassDeclaration> = resolver.findAnnotationsForClass(GenerateFactory::class)
 
         components.forEach { generateComponent(it) }

--- a/decompose-processor/src/jvmMain/kotlin/app/futured/arkitekt/factorygenerator/processor/ComponentFactoryProcessor.kt
+++ b/decompose-processor/src/jvmMain/kotlin/app/futured/arkitekt/factorygenerator/processor/ComponentFactoryProcessor.kt
@@ -11,7 +11,15 @@ import kotlin.reflect.KClass
 class ComponentFactoryProcessor(
     private val codeGenerator: CodeGenerator,
 ) : SymbolProcessor {
+
+    var invoked: Boolean = false
+
     override fun process(resolver: Resolver): List<KSAnnotated> {
+        if (invoked) {
+            return emptyList()
+        }
+        invoked = true
+
         val components: Sequence<KSClassDeclaration> = resolver.findAnnotationsForClass(GenerateFactory::class)
         components.forEach { generateComponent(it) }
         return emptyList()

--- a/decompose-processor/src/jvmMain/kotlin/app/futured/arkitekt/factorygenerator/processor/PoetFactoryComponentGenerator.kt
+++ b/decompose-processor/src/jvmMain/kotlin/app/futured/arkitekt/factorygenerator/processor/PoetFactoryComponentGenerator.kt
@@ -76,7 +76,10 @@ object PoetFactoryComponentGenerator {
 
         val fileSpec = createFileSpec(factoryClassName, componentTypeSpec)
 
-        fileSpec.writeTo(codeGenerator, aggregating = true)
+        // aggregating = false: each factory depends only on its own source class, not all files.
+        // originatingKSFiles defaults to FileSpec.originatingKSFiles, resolved automatically from
+        // the KS symbols added via toTypeName() calls in the contained declarations.
+        fileSpec.writeTo(codeGenerator, aggregating = false)
     }
 
     private fun createComponentTypeSpec(

--- a/decompose-processor/src/jvmMain/kotlin/app/futured/arkitekt/factorygenerator/processor/PoetFactoryComponentGenerator.kt
+++ b/decompose-processor/src/jvmMain/kotlin/app/futured/arkitekt/factorygenerator/processor/PoetFactoryComponentGenerator.kt
@@ -2,6 +2,7 @@ package app.futured.arkitekt.factorygenerator.processor
 
 import com.google.devtools.ksp.processing.CodeGenerator
 import com.google.devtools.ksp.symbol.KSClassDeclaration
+import com.google.devtools.ksp.symbol.KSFile
 import com.google.devtools.ksp.symbol.KSValueParameter
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.FileSpec
@@ -9,6 +10,7 @@ import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.KModifier
 import com.squareup.kotlinpoet.TypeName
 import com.squareup.kotlinpoet.TypeSpec
+import com.squareup.kotlinpoet.ksp.addOriginatingKSFile
 import com.squareup.kotlinpoet.ksp.toTypeName
 import com.squareup.kotlinpoet.ksp.writeTo
 
@@ -64,9 +66,13 @@ object PoetFactoryComponentGenerator {
             simpleNames = listOf("KoinComponent"),
         )
 
+        val originatingFile = factoryComponent.containingFile
+            ?: error("Unable to get containing file for ${factoryComponent.qualifiedName?.asString()}")
+
         val componentTypeSpec = createComponentTypeSpec(
             factoryClassName = factoryClassName,
             koinComponentClass = koinComponentClass,
+            originatingFile = originatingFile,
             createComponentFunction = createComponentFunction(
                 baseName,
                 factoryComponentPackageName,
@@ -76,17 +82,18 @@ object PoetFactoryComponentGenerator {
 
         val fileSpec = createFileSpec(factoryClassName, componentTypeSpec)
 
-        // aggregating = false: each factory depends only on its own source class, not all files.
-        // originatingKSFiles defaults to FileSpec.originatingKSFiles, resolved automatically from
-        // the KS symbols added via toTypeName() calls in the contained declarations.
+        // Each factory depends only on the annotated component that owns it.
+        // This lets KSP keep outputs for unchanged components during incremental builds.
         fileSpec.writeTo(codeGenerator, aggregating = false)
     }
 
     private fun createComponentTypeSpec(
         factoryClassName: ClassName,
         koinComponentClass: ClassName,
+        originatingFile: KSFile,
         createComponentFunction: FunSpec,
     ) = TypeSpec.objectBuilder(factoryClassName)
+        .addOriginatingKSFile(originatingFile)
         .addModifiers(KModifier.INTERNAL)
         .addSuperinterface(superinterface = koinComponentClass)
         .addFunction(createComponentFunction)


### PR DESCRIPTION
## Summary

This PR fixes unstable incremental KSP generation in `decompose-processor`. The processor generates one `*ComponentFactory.kt` file per `@GenerateFactory` component, but the generated files were not explicitly associated with the source file that produced them. Although the files were marked as isolating, KSP had no originating `KSFile` metadata for the outputs, so incremental builds could lose the relationship between an annotated component and its generated factory.

In a consuming KMP project this showed up as nondeterministic rebuild failures. A clean build generated all factories, but subsequent incremental runs could pass only a subset of annotated components to the processor. KSP then regenerated only that subset and removed the factories for unchanged components, causing unresolved references such as `FirstComponentFactory` or `LoginComponentFactory` until a clean build was run again.

## Fix

Each generated factory is now explicitly registered with the annotated component's containing source file via `addOriginatingKSFile(factoryComponent.containingFile)`. The generated file remains isolating (`aggregating = false`), which matches the actual dependency model: one factory depends on one component source file.

The previous one-shot `invoked` guard was removed so the processor can participate correctly in KSP rounds. With proper originating-file metadata, KSP can safely decide which factories to keep, remove, or regenerate during incremental processing instead of relying on skipping later rounds.

## Test plan

- [x] `./gradlew :decompose-processor:compileKotlinJvm`
- [x] Verified in a consuming KMP project with `:shared:feature:clean :shared:feature:compileCommonMainKotlinMetadata --refresh-dependencies --no-build-cache --no-configuration-cache`
- [x] Verified subsequent `:shared:feature:compileCommonMainKotlinMetadata` rebuild keeps all generated factories
- [x] Confirmed KSP cache maps each component source file to its corresponding generated factory output
