### PR TITLE
Bump Kotlin version to 2.4 

### DIFF
--- a/buildSrc/src/main/kotlin/Deps.kt
+++ b/buildSrc/src/main/kotlin/Deps.kt
@@ -24,6 +24,7 @@ object Deps {
         const val hiltPlugin = "com.google.dagger:hilt-android-gradle-plugin:${Versions.hilt}"
         const val hilt = "com.google.dagger:hilt-android:${Versions.hilt}"
         const val hiltCompiler = "com.google.dagger:hilt-android-compiler:${Versions.hilt}"
+        const val kotlinMetadata = "org.jetbrains.kotlin:kotlin-metadata-jvm:${Versions.kotlin}"
 
         const val hiltViewModelCompose = "androidx.hilt:hilt-lifecycle-viewmodel-compose:${Versions.hiltJetpack}"
     }

--- a/buildSrc/src/main/kotlin/Versions.kt
+++ b/buildSrc/src/main/kotlin/Versions.kt
@@ -10,7 +10,7 @@ object Versions {
     const val dokka = "1.6.10"
 
     // kotlin
-    const val kotlin = "2.3.10"
+    const val kotlin = "2.4.0"
     const val ksp = "2.3.5"
     const val coroutines = "1.10.2"
 

--- a/cr-usecases-test/build.gradle.kts
+++ b/cr-usecases-test/build.gradle.kts
@@ -29,9 +29,6 @@ android {
 
 kotlin {
     jvmToolchain(17)
-    compilerOptions {
-        freeCompilerArgs.add("-Xcontext-parameters")
-    }
 }
 
 mavenPublishing {

--- a/cr-usecases/build.gradle.kts
+++ b/cr-usecases/build.gradle.kts
@@ -17,10 +17,6 @@ kotlin {
         minSdk = ProjectSettings.minSdk
     }
 
-    compilerOptions {
-        freeCompilerArgs.add("-Xcontext-parameters")
-    }
-
     sourceSets {
         commonMain {
             dependencies {

--- a/cr-usecases/src/commonMain/kotlin/app/futured/arkitekt/crusecases/FlowUseCaseExecution.kt
+++ b/cr-usecases/src/commonMain/kotlin/app/futured/arkitekt/crusecases/FlowUseCaseExecution.kt
@@ -73,27 +73,3 @@ private fun <ARGS, T : Any?> FlowUseCase<ARGS, T>.internalExecute(
             }.catch { /* handled in onCompletion */ }
             .launchIn(coroutineScopeOwner.useCaseScope)
 }
-
-
-@Deprecated(
-    message = "Use the version with CoroutineScopeOwner as context parameter instead. Enable context parameters by adding '-Xcontext-receivers' compiler flag.",
-    replaceWith = ReplaceWith("execute(args, config)", imports = ["app.futured.arkitekt.crusecases.execute"])
-)
-fun <ARGS, T : Any?> FlowUseCase<ARGS, T>.execute(
-    args: ARGS,
-    coroutineScopeOwner: CoroutineScopeOwner,
-    config: FlowUseCaseConfig.Builder<T, T>.() -> Unit,
-) {
-    internalExecute(args, coroutineScopeOwner, config)
-}
-
-@Deprecated(
-    message = "Use the version with CoroutineScopeOwner as context parameter instead. Enable context parameters by adding '-Xcontext-receivers' compiler flag.",
-    replaceWith = ReplaceWith("execute(config)", imports = ["app.futured.arkitekt.crusecases.execute"])
-)
-fun <T : Any?> FlowUseCase<Unit, T>.execute(
-    coroutineScopeOwner: CoroutineScopeOwner,
-    config: FlowUseCaseConfig.Builder<T, T>.() -> Unit,
-) {
-    internalExecute(Unit, coroutineScopeOwner, config)
-}

--- a/cr-usecases/src/commonMain/kotlin/app/futured/arkitekt/crusecases/UseCaseExecution.kt
+++ b/cr-usecases/src/commonMain/kotlin/app/futured/arkitekt/crusecases/UseCaseExecution.kt
@@ -85,29 +85,6 @@ suspend fun <ARGS, T : Any?> UseCase<ARGS, T>.execute(
     }
 }
 
-@Deprecated(
-    message = "Use the version with CoroutineScopeOwner as context parameter instead. Enable context parameters by adding '-Xcontext-receivers' compiler flag.",
-    replaceWith = ReplaceWith("execute(args, config)", imports = ["app.futured.arkitekt.crusecases.execute"])
-)
-fun <ARGS, T : Any?> UseCase<ARGS, T>.execute(
-    args: ARGS,
-    coroutineScopeOwner: CoroutineScopeOwner,
-    config: UseCaseConfig.Builder<T>.() -> Unit,
-) {
-    internalExecute(args, coroutineScopeOwner, config)
-}
-
-@Deprecated(
-    message = "Use the version with CoroutineScopeOwner as context parameter instead. Enable context parameters by adding '-Xcontext-receivers' compiler flag.",
-    replaceWith = ReplaceWith("execute(args, config)", imports = ["app.futured.arkitekt.crusecases.execute"])
-)
-fun <T : Any?> UseCase<Unit, T>.execute(
-    coroutineScopeOwner: CoroutineScopeOwner,
-    config: UseCaseConfig.Builder<T>.() -> Unit,
-) {
-    internalExecute(Unit, coroutineScopeOwner, config)
-}
-
 private fun <ARGS, T : Any?> UseCase<ARGS, T>.internalExecute(
     args: ARGS,
     coroutineScopeOwner: CoroutineScopeOwner,

--- a/example/build.gradle.kts
+++ b/example/build.gradle.kts
@@ -45,9 +45,6 @@ android {
 
 kotlin {
     jvmToolchain(17)
-    compilerOptions {
-        freeCompilerArgs.add("-Xcontext-parameters")
-    }
 }
 
 dependencies {
@@ -75,6 +72,10 @@ dependencies {
 
     implementation(Deps.DI.hilt)
     ksp(Deps.DI.hiltCompiler)
+    // Overrides the older kotlin-metadata-jvm bundled by hilt-compiler so the KSP/Hilt
+    // processor can parse Kotlin 2.4.0 metadata (highest version on the processor classpath
+    // wins). Mirrors android/nowinandroid's fix for google/dagger#5001.
+    ksp(Deps.DI.kotlinMetadata)
 
     // Unit tests
     testImplementation(Deps.Test.jUnit)

--- a/example/src/main/java/app/futured/arkitekt/sample/ui/form/FormViewModel.kt
+++ b/example/src/main/java/app/futured/arkitekt/sample/ui/form/FormViewModel.kt
@@ -19,8 +19,7 @@ class FormViewModel @AssistedInject constructor(
 ) : BaseViewModel<FormViewState>() {
 
     init {
-        // example of usage without context parameter enabled
-        observeFormUseCase.execute(this) {
+        observeFormUseCase.execute {
             onNext { viewState.storedContent.value = "${it.first} ${it.second}" }
             onError { sendEvent(ShowToastEvent("Error :-(")) }
         }

--- a/example/src/main/java/app/futured/arkitekt/sample/ui/login/LoginViewModel.kt
+++ b/example/src/main/java/app/futured/arkitekt/sample/ui/login/LoginViewModel.kt
@@ -27,10 +27,8 @@ class LoginViewModel @Inject constructor(
     }
 
     fun logIn() = with(viewState) {
-        // example of usage without context parameter enabled
         loginCompletabler.execute(
             args = SyncLoginUseCase.LoginData(name.value, surname.value),
-            coroutineScopeOwner = this@LoginViewModel
         ) {
             onSuccess { sendEvent(ShowToastEvent("Successfully logged in!")) }
             onError { sendEvent(ShowToastEvent("Login error!")) }


### PR DESCRIPTION
Remove experimental compiler flag for context-parameters as they are promoted to stable in Kotlin 2.4

Unfortunately IDE didn't catch up yet as it spawns false positive warnings all over the place. We need to wait for 2026.1.2
in Quail 2 it is already fixed

https://youtrack.jetbrains.com/issue/KTIJ-38416/False-positive-context-parameters-requires-Xcontext-parameters-in-IDE-for-projects-using-Kotlin-2.4-where-the-flag-is-no-longer